### PR TITLE
#75 - Replace JUnit with TestNG in IntegrationTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Maven
 #
 **/target/
+**/test-output/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/studenthub-portal/pom.xml
+++ b/studenthub-portal/pom.xml
@@ -92,6 +92,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>6.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
@@ -108,8 +114,10 @@
         <configuration>
           <includes>
             <include>cz.studenthub.DAOTestSuite.java</include>
-            <include>cz.studenthub.IntegrationTestSuite.java</include>
           </includes>
+          <suiteXmlFiles>
+            <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+          </suiteXmlFiles>
         </configuration>
       </plugin>
       <plugin>

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/UserResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/UserResource.java
@@ -93,11 +93,12 @@ public class UserResource {
   @DELETE
   @Path("/{id}")
   @UnitOfWork
-  public Response delete(@Auth User user, @PathParam("id") LongParam idParam) {
+  public Response delete(@Auth User authUser, @PathParam("id") LongParam idParam) {
     Long id = idParam.get();
+    User user = userDao.findById(id);
 
     // only admin or profile owner is allowed
-    if (id.equals(user.getId()) || user.getRoles().contains(UserRole.ADMIN)) {
+    if (id.equals(authUser.getId()) || authUser.getRoles().contains(UserRole.ADMIN)) {
       userDao.delete(user);
       return Response.noContent().build();
     } else {
@@ -109,15 +110,16 @@ public class UserResource {
   @Path("/{id}")
   @UnitOfWork
   public Response update(@PathParam("id") LongParam idParam, @NotNull @Valid UpdateUserBean updateUserBean,
-      @Auth User user) {
+      @Auth User authUser) {
     
     Long id = idParam.get();
+    User user = userDao.findById(id);
 
     // roles update allowed only to admin
-    if (user.getRoles().contains(UserRole.ADMIN))
+    if (authUser.getRoles().contains(UserRole.ADMIN))
       user.setRoles(updateUserBean.getRoles());
     
-    if (id.equals(user.getId()) || user.getRoles().contains(UserRole.ADMIN)) {
+    if (id.equals(authUser.getId()) || authUser.getRoles().contains(UserRole.ADMIN)) {
       user.setName(updateUserBean.getName());
       user.setEmail(updateUserBean.getEmail());
       user.setFaculty(updateUserBean.getFaculty());

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyResourceTest.java
@@ -1,7 +1,7 @@
 package cz.studenthub.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.util.List;
 
@@ -11,48 +11,52 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
-import cz.studenthub.IntegrationTestSuite;
 import cz.studenthub.StudentHubConfiguration;
+import cz.studenthub.IntegrationTestSuite;
 import cz.studenthub.core.Company;
 import cz.studenthub.core.Topic;
 import cz.studenthub.core.User;
 import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.DropwizardTestSupport;
 import net.minidev.json.JSONObject;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class CompanyResourceTest {
-  public static final DropwizardAppRule<StudentHubConfiguration> DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+  public static DropwizardTestSupport<StudentHubConfiguration> DROPWIZARD;
 
-  private static Client client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("CompanyTest");
+  private static Client client;
+
+  @BeforeClass
+  public void setup() {
+      DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+      client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("CompanyTest");
+  }
 
   private List<Company> fetchFaculties() {
     return client.target(String.format("http://localhost:%d/api/companies/", DROPWIZARD.getLocalPort()))
       .request().get(new GenericType<List<Company>>(){});
   }
 
-  @Test
+  @Test(dependsOnGroups = "migrate")
   public void listCompanies() {
     List<Company> list = fetchFaculties();
 
     assertNotNull(list);
-    assertEquals(8, list.size());
+    assertEquals(list.size(), 8);
   }
 
-  @Test
+  @Test(dependsOnGroups = "login")
   public void fetchCompany() {
     Company company = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/companies/5", DROPWIZARD.getLocalPort()))
         .request(MediaType.APPLICATION_JSON), client).get(Company.class);
 
     assertNotNull(company);
-    assertEquals("Company Five", company.getName());
+    assertEquals(company.getName(), "Company Five");
   }
 
-  @Test
+  @Test(dependsOnMethods = "listCompanies")
   public void createCompany() {
     JSONObject company = new JSONObject();
     company.put("name", "New Company");
@@ -61,36 +65,36 @@ public class CompanyResourceTest {
       .request(MediaType.APPLICATION_JSON), client).post(Entity.json(company.toJSONString()));
 
     assertNotNull(response);
-    assertEquals(201, response.getStatus());
-    assertEquals(9, fetchFaculties().size());
+    assertEquals(response.getStatus(), 201);
+    assertEquals(fetchFaculties().size(), 9);
   }
 
-  @Test
+  @Test(dependsOnMethods = "createCompany")
   public void updateCompany() {
     JSONObject company = new JSONObject();
     company.put("url", "past.me");
     company.put("name", "New Company");
 
-    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/companies/5", DROPWIZARD.getLocalPort()))
+    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/companies/9", DROPWIZARD.getLocalPort()))
       .request(MediaType.APPLICATION_JSON), client).put(Entity.json(company.toJSONString()));
 
     assertNotNull(response);
-    assertEquals(200, response.getStatus());
-    assertEquals("past.me", response.readEntity(Company.class).getUrl());
+    assertEquals(response.getStatus(), 200);
+    assertEquals(response.readEntity(Company.class).getUrl(), "past.me");
   }
 
-  @Test
+  @Test(dependsOnMethods = "updateCompany")
   public void deleteCompany() {
     Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/companies/9", DROPWIZARD.getLocalPort())).request(), client)
       .delete();
     List<Company> list = fetchFaculties();
 
     assertNotNull(response);
-    assertEquals(204, response.getStatus());
-    assertEquals(8, list.size());
+    assertEquals(response.getStatus(), 204);
+    assertEquals(list.size(), 8);
   }
 
-  @Test
+  @Test(dependsOnGroups = "login")
   public void getLeaders() {
     List<User> users = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/companies/5/leaders", DROPWIZARD.getLocalPort()))
         .request(MediaType.APPLICATION_JSON), client).get(new GenericType<List<User>>(){});
@@ -99,7 +103,7 @@ public class CompanyResourceTest {
     assertEquals(1, users.size());
   }
 
-  @Test
+  @Test(dependsOnGroups = "login")
   public void getTopics() {
     List<Topic> topics = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/companies/5/topics", DROPWIZARD.getLocalPort()))
         .request(MediaType.APPLICATION_JSON), client).get(new GenericType<List<Topic>>(){});

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/FacultyResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/FacultyResourceTest.java
@@ -11,47 +11,51 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import cz.studenthub.IntegrationTestSuite;
 import cz.studenthub.StudentHubConfiguration;
 import cz.studenthub.core.Faculty;
 import cz.studenthub.core.User;
 import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.DropwizardTestSupport;
 import net.minidev.json.JSONObject;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class FacultyResourceTest {
-  public static final DropwizardAppRule<StudentHubConfiguration> DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+  public static DropwizardTestSupport<StudentHubConfiguration> DROPWIZARD;
 
-  private static Client client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("FacultyTest");
+  private static Client client;
+
+  @BeforeClass
+  public void setup() {
+      DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+      client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("FacultyTest");
+  }
 
   private List<Faculty> fetchFaculties() {
     return client.target(String.format("http://localhost:%d/api/faculties", DROPWIZARD.getLocalPort()))
       .request().get(new GenericType<List<Faculty>>(){});
   }
 
-  @Test
+  @Test(dependsOnGroups = "migrate")
   public void listFaculties() {
     List<Faculty> list = fetchFaculties();
 
     assertNotNull(list);
-    assertEquals(13, list.size());
+    assertEquals(list.size(), 13);
   }
 
-  @Test
+  @Test(dependsOnGroups = "login")
   public void fetchFaculty() {
     Faculty fac = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/faculties/1", DROPWIZARD.getLocalPort()))
         .request(MediaType.APPLICATION_JSON), client).get(Faculty.class);
 
     assertNotNull(fac);
-    assertEquals("Faculty of Informatics", fac.getName());
+    assertEquals(fac.getName(), "Faculty of Informatics");
   }
 
-  @Test
+  @Test(dependsOnGroups = "login", dependsOnMethods = "listFaculties")
   public void createFaculty() {
     JSONObject university = new JSONObject();
     university.put("id", 5);
@@ -64,11 +68,11 @@ public class FacultyResourceTest {
       .request(MediaType.APPLICATION_JSON), client).post(Entity.json(faculty.toJSONString()));
 
     assertNotNull(response);
-    assertEquals(201, response.getStatus());
-    assertEquals(14, fetchFaculties().size());
+    assertEquals(response.getStatus(), 201);
+    assertEquals(fetchFaculties().size(), 14);
   }
 
-  @Test
+  @Test(dependsOnMethods = "createFaculty")
   public void updateFaculty() {
     JSONObject university = new JSONObject();
     university.put("id", 5);
@@ -77,40 +81,40 @@ public class FacultyResourceTest {
     faculty.put("name", "New");
     faculty.put("university", university);
 
-    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/faculties/5", DROPWIZARD.getLocalPort()))
+    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/faculties/14", DROPWIZARD.getLocalPort()))
       .request(MediaType.APPLICATION_JSON), client).put(Entity.json(faculty.toJSONString()));
 
     assertNotNull(response);
-    assertEquals(200, response.getStatus());
-    assertEquals("New", response.readEntity(Faculty.class).getName());
+    assertEquals(response.getStatus(), 200);
+    assertEquals(response.readEntity(Faculty.class).getName(), "New");
   }
 
-  @Test
+  @Test(dependsOnMethods = "updateFaculty")
   public void deleteFaculty() {
     Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/faculties/14", DROPWIZARD.getLocalPort())).request(), client)
       .delete();
 
     assertNotNull(response);
-    assertEquals(204, response.getStatus());
-    assertEquals(13, fetchFaculties().size());
+    assertEquals(response.getStatus(), 204);
+    assertEquals(fetchFaculties().size(), 13);
   }
 
-  @Test
+  @Test(dependsOnGroups = "login")
   public void getStudents() {
     List<User> users = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/faculties/1/students", DROPWIZARD.getLocalPort()))
         .request(MediaType.APPLICATION_JSON), client).get(new GenericType<List<User>>(){});
 
     assertNotNull(users);
-    assertEquals(2, users.size());
+    assertEquals(users.size(), 2);
   }
 
-  @Test
+  @Test(dependsOnGroups = "login")
   public void getSupervisors() {
     List<User> users = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/faculties/2/supervisors", DROPWIZARD.getLocalPort()))
         .request(MediaType.APPLICATION_JSON), client).get(new GenericType<List<User>>(){});
 
     assertNotNull(users);
-    assertEquals(2, users.size());
+    assertEquals(users.size(), 2);
   }
 
 }

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/LoginResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/LoginResourceTest.java
@@ -1,29 +1,35 @@
 package cz.studenthub.integration;
 
-import static org.junit.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 
-import org.junit.Test;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import cz.studenthub.IntegrationTestSuite;
 import cz.studenthub.StudentHubConfiguration;
 import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.DropwizardTestSupport;
 
 public class LoginResourceTest {
-  public static final DropwizardAppRule<StudentHubConfiguration> DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+  public static DropwizardTestSupport<StudentHubConfiguration> DROPWIZARD;
 
-  public static Client client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("LoginTest");
+  private static Client client;
 
-  @Test
+  @BeforeClass
+  public void setup() {
+      DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+      client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("LoginTest");
+  }
+
+  @Test(groups = "login", dependsOnGroups = "migrate")
   public void loginTest() {
-    Response response = client.target(
-        String.format("http://localhost:%d/api/auth/login", DROPWIZARD.getLocalPort()))
-        .queryParam("username", "superadmin@example.com")
-        .queryParam("password", "test").request().post(null);
-    assertEquals(200, response.getStatus());
-    assertNotNull(response.getHeaderString("Authorization"));
+    Response response = IntegrationTestSuite.authorizationRequest(client, IntegrationTestSuite.USERNAME, IntegrationTestSuite.PASSWORD);
+
+    assertEquals(response.getStatus(), 200);
+    assertNotNull(response.getCookies().get("sh-token").getValue());
   }
 }

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/TagResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/TagResourceTest.java
@@ -1,42 +1,50 @@
 package cz.studenthub.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.util.List;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.GenericType;
-import org.junit.Test;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import cz.studenthub.IntegrationTestSuite;
 import cz.studenthub.StudentHubConfiguration;
 import cz.studenthub.core.Topic;
 import cz.studenthub.core.User;
 import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.DropwizardTestSupport;
 
 public class TagResourceTest {
-  public static final DropwizardAppRule<StudentHubConfiguration> DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+  public static DropwizardTestSupport<StudentHubConfiguration> DROPWIZARD;
 
-  private static Client client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("TagTest");
+  private static Client client;
 
-  @Test
+  @BeforeClass
+  public void setup() {
+      DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+      client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("TagTest");
+  }
+
+  @Test(dependsOnGroups = "login")
   public void listUsers() {
     List<User> list = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/tags/Java/users", DROPWIZARD.getLocalPort()))
         .request(), client).get(new GenericType<List<User>>(){});
 
     assertNotNull(list);
-    assertEquals(4, list.size());
+    assertEquals(list.size(), 4);
   }
 
-  @Test
+  @Test(dependsOnGroups = "migrate")
   public void listTopic() {
-    List<Topic> list = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/tags/Java/topics", DROPWIZARD.getLocalPort()))
-        .request(), client).get(new GenericType<List<Topic>>(){});
+    List<Topic> list = client.target(String.format("http://localhost:%d/api/tags/Java/topics", DROPWIZARD.getLocalPort()))
+        .request()
+        .get(new GenericType<List<Topic>>(){});
 
     assertNotNull(list);
-    assertEquals(2, list.size());
+    assertEquals(list.size(), 2);
   }
 
 }

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/TaskResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/TaskResourceTest.java
@@ -1,40 +1,44 @@
 package cz.studenthub.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 import cz.studenthub.IntegrationTestSuite;
 import cz.studenthub.StudentHubConfiguration;
 import cz.studenthub.core.Task;
 import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.dropwizard.testing.DropwizardTestSupport;
 import net.minidev.json.JSONObject;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TaskResourceTest {
-  public static final DropwizardAppRule<StudentHubConfiguration> DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+  public static DropwizardTestSupport<StudentHubConfiguration> DROPWIZARD;
 
-  private static Client client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("TaskTest");
+  private static Client client;
 
-  @Test
+  @BeforeClass
+  public void setup() {
+      DROPWIZARD = IntegrationTestSuite.DROPWIZARD;
+      client = new JerseyClientBuilder(DROPWIZARD.getEnvironment()).build("TaskTest");
+  }
+
+  @Test(dependsOnGroups = "login")
   public void fetchTask() {
     Task task = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/tasks/1", DROPWIZARD.getLocalPort()))
         .request(MediaType.APPLICATION_JSON), client).get(Task.class);
 
     assertNotNull(task);
-    assertEquals("Reduce size", task.getTitle());
+    assertEquals(task.getTitle(), "Reduce size");
   }
 
-  @Test
+  @Test(dependsOnGroups = "login")
   public void createTask() {
     JSONObject application = new JSONObject();
     application.put("id", 1);
@@ -47,11 +51,11 @@ public class TaskResourceTest {
       .request(MediaType.APPLICATION_JSON), client).post(Entity.json(app.toJSONString()));
 
     assertNotNull(response);
-    assertEquals(201, response.getStatus());
-    assertEquals(4, TopicApplicationResourceTest.fetchTasks().size());
+    assertEquals(response.getStatus(), 201);
+    assertEquals(TopicApplicationResourceTest.fetchTasks().size(), 4);
   }
 
-  @Test
+  @Test(dependsOnMethods = "createTask")
   public void updateTask() {
     JSONObject application = new JSONObject();
     application.put("id", 1);
@@ -60,24 +64,24 @@ public class TaskResourceTest {
     app.put("title", "New");
     app.put("application", application);
 
-    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/tasks/6", DROPWIZARD.getLocalPort()))
+    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/tasks/7", DROPWIZARD.getLocalPort()))
       .request(MediaType.APPLICATION_JSON), client).put(Entity.json(app.toJSONString()));
 
     assertNotNull(response);
-    assertEquals(200, response.getStatus());
+    assertEquals(response.getStatus(), 200);
 
     Task task = response.readEntity(Task.class);
-    assertEquals("New", task.getTitle());
-    assertEquals(1, (long) task.getApplication().getId());
+    assertEquals(task.getTitle(), "New");
+    assertEquals((long) task.getApplication().getId(), 1);
   }
 
-  @Test
+  @Test(dependsOnMethods = "updateTask")
   public void deleteTask() {
     Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/tasks/7", DROPWIZARD.getLocalPort())).request(), client)
       .delete();
 
     assertNotNull(response);
-    assertEquals(204, response.getStatus());
-    assertEquals(3, TopicApplicationResourceTest.fetchTasks().size());
+    assertEquals(response.getStatus(), 204);
+    assertEquals(TopicApplicationResourceTest.fetchTasks().size(), 3);
   }
 }

--- a/studenthub-portal/src/test/resources/config-test.yml
+++ b/studenthub-portal/src/test/resources/config-test.yml
@@ -32,3 +32,11 @@ database:
   # validate schema
   properties:
     hibernate.hbm2ddl.auto: update
+smtp:
+  server: localhost
+  port: 587
+  username: ${SMTP_USERNAME}
+  password: ${SMTP_PASSWORD}
+  fromEmail: admin@example.com
+  fromName: admin
+  

--- a/studenthub-portal/src/test/resources/testng.xml
+++ b/studenthub-portal/src/test/resources/testng.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+ 
+<suite name="IntegrationTestSuite" verbose="1" >
+	<test name="Integration Tests"   >
+	    <classes>
+	        <class name="cz.studenthub.IntegrationTestSuite"/>
+	        <class name="cz.studenthub.integration.LoginResourceTest"/>
+	        <class name="cz.studenthub.integration.CompanyResourceTest"/>
+	        <class name="cz.studenthub.integration.UniversityResourceTest"/>
+	        <class name="cz.studenthub.integration.FacultyResourceTest"/>
+	        <class name="cz.studenthub.integration.TopicResourceTest"/>
+	        <class name="cz.studenthub.integration.UserResourceTest"/>
+	        <class name="cz.studenthub.integration.TopicApplicationResourceTest"/>
+	        <class name="cz.studenthub.integration.TaskResourceTest"/>
+	        <class name="cz.studenthub.integration.TagResourceTest"/>
+	    </classes>
+    </test>
+</suite>


### PR DESCRIPTION
* IntegrationTests are now run with TestNG.
  * Migration of testDB is now first test and all other tests, depend on it.
  * Login is second test and all tests that need it depend on it.
  * All create/update/delete tests in classes are now run in fixed order and affect only newly created entity.
   * Test authentication is now done with Basic Auth.
* Fixed #90. 