### PR TITLE
#84 - Activations are now stored in DB

### DIFF
--- a/studenthub-portal/src/main/java/cz/studenthub/StudentHubApplication.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/StudentHubApplication.java
@@ -30,6 +30,7 @@ import cz.studenthub.auth.BasicAuthenticator;
 import cz.studenthub.auth.JwtCookieAuthFilter;
 import cz.studenthub.auth.StudentHubAuthorizer;
 import cz.studenthub.auth.TokenAuthenticator;
+import cz.studenthub.core.Activation;
 import cz.studenthub.core.Company;
 import cz.studenthub.core.Faculty;
 import cz.studenthub.core.Task;
@@ -37,6 +38,7 @@ import cz.studenthub.core.Topic;
 import cz.studenthub.core.TopicApplication;
 import cz.studenthub.core.University;
 import cz.studenthub.core.User;
+import cz.studenthub.db.ActivationDAO;
 import cz.studenthub.db.CompanyDAO;
 import cz.studenthub.db.FacultyDAO;
 import cz.studenthub.db.TaskDAO;
@@ -90,7 +92,7 @@ public class StudentHubApplication extends Application<StudentHubConfiguration> 
    */
   private final HibernateBundle<StudentHubConfiguration> hibernate = new HibernateBundle<StudentHubConfiguration>(
       // list of entities
-      User.class, Topic.class, TopicApplication.class, Company.class, University.class, Faculty.class, Task.class) {
+      User.class, Topic.class, TopicApplication.class, Company.class, University.class, Faculty.class, Task.class, Activation.class) {
 
     @Override
     public DataSourceFactory getDataSourceFactory(StudentHubConfiguration configuration) {
@@ -139,6 +141,7 @@ public class StudentHubApplication extends Application<StudentHubConfiguration> 
     final TopicDAO topicDao = new TopicDAO(hibernate.getSessionFactory());
     final TopicApplicationDAO taDao = new TopicApplicationDAO(hibernate.getSessionFactory());
     final TaskDAO taskDao = new TaskDAO(hibernate.getSessionFactory());
+    final ActivationDAO actDao = new ActivationDAO(hibernate.getSessionFactory());
 
     // enable session manager
     environment.servlets().setSessionHandler(new SessionHandler());
@@ -152,7 +155,7 @@ public class StudentHubApplication extends Application<StudentHubConfiguration> 
     environment.jersey().register(new TopicApplicationResource(taDao, taskDao));
     environment.jersey().register(new TaskResource(taDao, taskDao));
     environment.jersey().register(new LoginResource(userDao));
-    environment.jersey().register(new RegistrationResource(userDao, configuration.getSmtpConfig()));
+    environment.jersey().register(new RegistrationResource(userDao, actDao, configuration.getSmtpConfig()));
     environment.jersey().register(new TagResource(userDao, topicDao));
 
     // set up auth

--- a/studenthub-portal/src/main/java/cz/studenthub/core/Activation.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/Activation.java
@@ -1,0 +1,93 @@
+package cz.studenthub.core;
+
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+import cz.studenthub.auth.StudentHubPasswordEncoder;
+
+@Entity
+@Table(name = "Activations")
+@NamedQueries({ @NamedQuery(name = "Activation.findByUser", query = "SELECT activation FROM Activation activation WHERE user = :user"),
+  @NamedQuery(name = "Activation.findAll", query = "SELECT activation FROM Activation activation")})
+public class Activation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @OneToOne
+    private User user;
+
+    @NotEmpty
+    private String activationCode;
+
+    public Activation(){
+    }
+
+    public Activation(User user, String activationCode) {
+      this.user = user;
+      this.activationCode = activationCode;
+    }
+
+    public Activation(User user) {
+      this(user, StudentHubPasswordEncoder.genSecret());
+    }
+
+    public Long getId() {
+      return id;
+    }
+
+    public void setId(Long id) {
+      this.id = id;
+    }
+
+    public User getUser() {
+      return user;
+    }
+
+    public void setUser(User user) {
+      this.user = user;
+    }
+
+    public String getActivationCode() {
+      return activationCode;
+    }
+
+    public void setActivationCode(String activationCode) {
+      this.activationCode = activationCode;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(user, activationCode);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if ((obj == null) || (getClass() != obj.getClass())) {
+        return false;
+      }
+
+      return Integer.compare(this.hashCode(), obj.hashCode()) == 0;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Activation[user=%d, code=%s]", user.getId(), activationCode);
+    }
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/core/User.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/User.java
@@ -48,7 +48,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
     @NamedQuery(name = "User.findByRoleAndFaculty", query = "SELECT user FROM User user join user.roles role WHERE user.faculty = :faculty and role = :role"),
     @NamedQuery(name = "User.findByRoleAndCompany", query = "SELECT user FROM User user join user.roles role WHERE user.company = :company and role = :role"),
     @NamedQuery(name = "User.findByTag", query = "SELECT user FROM User user join user.tags tag WHERE tag = :tag"),
-    @NamedQuery(name = "User.findByEmail", query = "SELECT user FROM User user WHERE user.email = :email")})
+    @NamedQuery(name = "User.findByEmail", query = "SELECT user FROM User user WHERE user.email = :email"),
+    @NamedQuery(name = "User.findByUsername", query = "SELECT user FROM User user WHERE user.username = :username")})
 public class User implements Principal {
 
   @Id

--- a/studenthub-portal/src/main/java/cz/studenthub/db/ActivationDAO.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/db/ActivationDAO.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *     Copyright (C) 2016  Stefan Bunciak
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
+package cz.studenthub.db;
+
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+
+import cz.studenthub.core.Activation;
+import cz.studenthub.core.User;
+import io.dropwizard.hibernate.AbstractDAO;
+
+/**
+ * Data(base) Access Object for Company objects.
+ * 
+ * @author sbunciak
+ * @since 1.0
+ */
+public class ActivationDAO extends AbstractDAO<Activation> {
+
+  public ActivationDAO(SessionFactory sessionFactory) {
+    super(sessionFactory);
+  }
+
+  public Activation update(Activation activation) {
+    currentSession().clear();
+    return persist(activation);
+  }
+  
+  public Activation create(Activation activation) {
+    return persist(activation);
+  }
+
+  public Activation findById(long id) {
+    return get(id);
+  }
+
+  public Activation findByUser(User user) {
+    return uniqueResult(namedQuery("Activation.findByUser").setParameter("user", user));
+  }
+
+  public List<Activation> findAll() {
+    return list(namedQuery("Activation.findAll"));
+  }
+
+  public void delete(Activation activation) {
+    currentSession().delete(activation);
+  }
+
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/db/UserDAO.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/db/UserDAO.java
@@ -55,6 +55,10 @@ public class UserDAO extends AbstractDAO<User> {
     return uniqueResult(namedQuery("User.findByEmail").setParameter("email", email));
   }
 
+  public User findByUsername(String username) {
+    return uniqueResult(namedQuery("User.findByUsername").setParameter("username", username));
+  }
+
   public List<User> findByRole(UserRole role) {
     return list(namedQuery("User.findByRole").setParameter("role", role));
   }

--- a/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -1,27 +1,22 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-    <changeSet author="phala (generated)" id="1490799716747-1" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
-        <createSequence catalogName="studenthub" schemaName="public" sequenceName="companies_id_seq"/>
+    <changeSet author="phala (generated)" id="1496736526246-1">
+        <createTable catalogName="studenthub" schemaName="public" tableName="activations">
+            <column autoIncrement="true" name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" primaryKeyName="activations_pkey"/>
+            </column>
+            <column name="activationcode" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-2" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
-        <createSequence catalogName="studenthub" schemaName="public" sequenceName="faculties_id_seq"/>
-    </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-3" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
-        <createSequence catalogName="studenthub" schemaName="public" sequenceName="topicapplications_id_seq"/>
-    </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-4" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
-        <createSequence catalogName="studenthub" schemaName="public" sequenceName="topics_id_seq"/>
-    </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-5" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
-        <createSequence catalogName="studenthub" schemaName="public" sequenceName="universities_id_seq"/>
-    </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-6" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
-        <createSequence catalogName="studenthub" schemaName="public" sequenceName="users_id_seq"/>
-    </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-7" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-2">
         <createTable catalogName="studenthub" schemaName="public" tableName="companies">
             <column autoIncrement="true" name="id" type="BIGSERIAL">
-                <constraints primaryKey="true" primaryKeyName="constraint_5"/>
+                <constraints primaryKey="true" primaryKeyName="companies_pkey"/>
             </column>
             <column name="city" type="VARCHAR(255)"/>
             <column name="country" type="VARCHAR(255)"/>
@@ -34,7 +29,7 @@
             <column name="url" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-8" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-3">
         <createTable catalogName="studenthub" schemaName="public" tableName="faculties">
             <column autoIncrement="true" name="id" type="BIGSERIAL">
                 <constraints primaryKey="true" primaryKeyName="faculties_pkey"/>
@@ -43,11 +38,28 @@
                 <constraints nullable="false"/>
             </column>
             <column name="university_id" type="BIGINT">
-                 <constraints nullable="false"/>
+                <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-9" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-4">
+        <createTable catalogName="studenthub" schemaName="public" tableName="tasks">
+            <column autoIncrement="true" name="id" type="BIGSERIAL">
+                <constraints primaryKey="true" primaryKeyName="tasks_pkey"/>
+            </column>
+            <column name="completed" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deadline" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
+            <column name="title" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="application_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="phala (generated)" id="1496736526246-5">
         <createTable catalogName="studenthub" schemaName="public" tableName="topic_degrees">
             <column name="topic_id" type="BIGINT">
                 <constraints nullable="false"/>
@@ -55,7 +67,7 @@
             <column name="degrees" type="INT"/>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-10" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-6">
         <createTable catalogName="studenthub" schemaName="public" tableName="topic_tags">
             <column name="topic_id" type="BIGINT">
                 <constraints nullable="false"/>
@@ -63,7 +75,7 @@
             <column name="tags" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-11" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-7">
         <createTable catalogName="studenthub" schemaName="public" tableName="topicapplications">
             <column autoIncrement="true" name="id" type="BIGSERIAL">
                 <constraints primaryKey="true" primaryKeyName="topicapplications_pkey"/>
@@ -78,15 +90,15 @@
                 <constraints nullable="false"/>
             </column>
             <column name="student_id" type="BIGINT">
-                 <constraints nullable="false"/>
+                <constraints nullable="false"/>
             </column>
             <column name="techleader_id" type="BIGINT"/>
             <column name="topic_id" type="BIGINT">
-                 <constraints nullable="false"/>
+                <constraints nullable="false"/>
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-12" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-8">
         <createTable catalogName="studenthub" schemaName="public" tableName="topics">
             <column autoIncrement="true" name="id" type="BIGSERIAL">
                 <constraints primaryKey="true" primaryKeyName="topics_pkey"/>
@@ -104,7 +116,7 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-13" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-9">
         <createTable catalogName="studenthub" schemaName="public" tableName="topics_users">
             <column name="topic_id" type="BIGINT">
                 <constraints nullable="false"/>
@@ -114,7 +126,7 @@
             </column>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-14" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-10">
         <createTable catalogName="studenthub" schemaName="public" tableName="universities">
             <column autoIncrement="true" name="id" type="BIGSERIAL">
                 <constraints primaryKey="true" primaryKeyName="universities_pkey"/>
@@ -128,7 +140,7 @@
             <column name="url" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-15" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-11">
         <createTable catalogName="studenthub" schemaName="public" tableName="user_roles">
             <column name="user_id" type="BIGINT">
                 <constraints nullable="false"/>
@@ -136,7 +148,7 @@
             <column name="roles" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-16" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-12">
         <createTable catalogName="studenthub" schemaName="public" tableName="user_tags">
             <column name="user_id" type="BIGINT">
                 <constraints nullable="false"/>
@@ -144,7 +156,7 @@
             <column name="tags" type="VARCHAR(255)"/>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-17" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-13">
         <createTable catalogName="studenthub" schemaName="public" tableName="users">
             <column autoIncrement="true" name="id" type="BIGSERIAL">
                 <constraints primaryKey="true" primaryKeyName="users_pkey"/>
@@ -165,78 +177,64 @@
             <column name="faculty_id" type="BIGINT"/>
         </createTable>
     </changeSet>
-    <changeSet author="phala (generated)" id="1492066089219-3">
-        <createTable catalogName="studenthub" schemaName="public" tableName="tasks">
-            <column autoIncrement="true" name="id" type="BIGSERIAL">
-                <constraints primaryKey="true" primaryKeyName="tasks_pkey"/>
-            </column>
-            <column name="completed" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
-            <column name="deadline" type="TIMESTAMP(6) WITHOUT TIME ZONE"/>
-            <column name="title" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="application_id" type="BIGINT">
-                 <constraints nullable="false"/>
-            </column>
-        </createTable>
-    </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-18" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-14">
         <addPrimaryKey catalogName="studenthub" columnNames="topic_id, academicsupervisors_id" constraintName="topics_users_pkey" schemaName="public" tableName="topics_users"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-19" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-15">
         <addUniqueConstraint catalogName="studenthub" columnNames="username" constraintName="uk_23y4gd49ajvbqgl3psjsvhff6" schemaName="public" tableName="users"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-20" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-16">
         <addUniqueConstraint catalogName="studenthub" columnNames="email" constraintName="uk_ncoa9bfasrql0x4nhmh1plxxy" schemaName="public" tableName="users"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-21" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-17">
         <addForeignKeyConstraint baseColumnNames="faculty_id" baseTableCatalogName="studenthub" baseTableName="users" baseTableSchemaName="public" constraintName="fk5aolvsnrulsfimxs1y9pqkehf" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="faculties" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-22" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-18">
         <addForeignKeyConstraint baseColumnNames="user_id" baseTableCatalogName="studenthub" baseTableName="user_roles" baseTableSchemaName="public" constraintName="fk5jomdmamtww9tntv3dgro711a" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-23" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-19">
         <addForeignKeyConstraint baseColumnNames="creator_id" baseTableCatalogName="studenthub" baseTableName="topics" baseTableSchemaName="public" constraintName="fk6xems514wsewyugbc19l840sk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-24" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-20">
         <addForeignKeyConstraint baseColumnNames="topic_id" baseTableCatalogName="studenthub" baseTableName="topics_users" baseTableSchemaName="public" constraintName="fk8tl27xuij7jgbcupvichjjx1p" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="topics" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-25" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-21">
         <addForeignKeyConstraint baseColumnNames="academicsupervisors_id" baseTableCatalogName="studenthub" baseTableName="topics_users" baseTableSchemaName="public" constraintName="fkayrerqlgcob2ivtlyc38fsitc" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-26" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-22">
         <addForeignKeyConstraint baseColumnNames="academicsupervisor_id" baseTableCatalogName="studenthub" baseTableName="topicapplications" baseTableSchemaName="public" constraintName="fkbm2weoaaacr3xur7n9wdw4ijy" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-27" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-23">
         <addForeignKeyConstraint baseColumnNames="faculty_id" baseTableCatalogName="studenthub" baseTableName="topicapplications" baseTableSchemaName="public" constraintName="fkbrl003w841tv48et4vrdrwrqg" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="faculties" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-28" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-24">
         <addForeignKeyConstraint baseColumnNames="user_id" baseTableCatalogName="studenthub" baseTableName="user_tags" baseTableSchemaName="public" constraintName="fki4g14759y17yab655w1bgp4rm" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-29" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-25">
         <addForeignKeyConstraint baseColumnNames="university_id" baseTableCatalogName="studenthub" baseTableName="faculties" baseTableSchemaName="public" constraintName="fkia0jky708onkbca0anbl10dp5" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="universities" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-30" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-26">
         <addForeignKeyConstraint baseColumnNames="topic_id" baseTableCatalogName="studenthub" baseTableName="topic_degrees" baseTableSchemaName="public" constraintName="fkls1i9mdx6fgb4q291cp2sefg4" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="topics" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-31" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-27">
         <addForeignKeyConstraint baseColumnNames="topic_id" baseTableCatalogName="studenthub" baseTableName="topicapplications" baseTableSchemaName="public" constraintName="fkmdsdlwba7jqa8fj5imcbcv0bi" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="topics" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-32" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-28">
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableCatalogName="studenthub" baseTableName="activations" baseTableSchemaName="public" constraintName="fko7msy6sghrksg7w9up2m9pl0n" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
+    </changeSet>
+    <changeSet author="phala (generated)" id="1496736526246-29">
         <addForeignKeyConstraint baseColumnNames="topic_id" baseTableCatalogName="studenthub" baseTableName="topic_tags" baseTableSchemaName="public" constraintName="fkolrr4uficcjmp6327mw4244t6" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="topics" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-33" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-30">
         <addForeignKeyConstraint baseColumnNames="student_id" baseTableCatalogName="studenthub" baseTableName="topicapplications" baseTableSchemaName="public" constraintName="fkp4fj9l3renicmx26dv9ex1rv0" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1492066089219-30">
+    <changeSet author="phala (generated)" id="1496736526246-31">
         <addForeignKeyConstraint baseColumnNames="application_id" baseTableCatalogName="studenthub" baseTableName="tasks" baseTableSchemaName="public" constraintName="fkpftkfrxc9ovrpjj2o05p3a6jk" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="topicapplications" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-34" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-32">
         <addForeignKeyConstraint baseColumnNames="company_id" baseTableCatalogName="studenthub" baseTableName="users" baseTableSchemaName="public" constraintName="fkqfg0pbnbv8iyd5may5o9fmcs" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="companies" referencedTableSchemaName="public"/>
     </changeSet>
-    <changeSet author="phala (generated)" id="1490799716747-35" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1496736526246-33">
         <addForeignKeyConstraint baseColumnNames="techleader_id" baseTableCatalogName="studenthub" baseTableName="topicapplications" baseTableSchemaName="public" constraintName="fktetxhwl3bqglxcp0tjqi54s12" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
 </databaseChangeLog>

--- a/studenthub-portal/src/main/resources/templates/setPassword.html
+++ b/studenthub-portal/src/main/resources/templates/setPassword.html
@@ -35,7 +35,7 @@
               <tr>
                 <td valign="top" class="email-body">
                   <p>Thank you __name__ for registering at Student Hub portal.</p>
-                  <p>Click <a href="https://portal.studenthub.cz/activate?key=__secret__&id=__id__">here</a> to activate your account by setting a new password.</p>
+                  <p>Click <a href="https://portal.studenthub.cz/activate?secret=__secret__&id=__id__">here</a> to activate your account by setting a new password.</p>
               </tr>
               <tr>
                 <td class="email-footer" align="center" valign="top">

--- a/studenthub-portal/src/test/java/cz/studenthub/DAOTestSuite.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/DAOTestSuite.java
@@ -15,6 +15,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import cz.studenthub.core.Activation;
 import cz.studenthub.core.Company;
 import cz.studenthub.core.Faculty;
 import cz.studenthub.core.Task;
@@ -22,6 +23,7 @@ import cz.studenthub.core.Topic;
 import cz.studenthub.core.TopicApplication;
 import cz.studenthub.core.University;
 import cz.studenthub.core.User;
+import cz.studenthub.db.ActivationDAOTest;
 import cz.studenthub.db.CompanyDAOTest;
 import cz.studenthub.db.FacultyDAOTest;
 import cz.studenthub.db.TaskDAOTest;
@@ -41,7 +43,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 
 @RunWith(Suite.class)
 @SuiteClasses({ CompanyDAOTest.class, FacultyDAOTest.class, TaskDAOTest.class, TopicApplicationDAOTest.class,
-   TopicDAOTest.class, UniversityDAOTest.class, UserDAOTest.class})
+   TopicDAOTest.class, UniversityDAOTest.class, UserDAOTest.class, ActivationDAOTest.class})
 public class DAOTestSuite {
 
   public static DAOTestRule database;
@@ -64,7 +66,8 @@ public class DAOTestSuite {
         .addEntityClass(Faculty.class)
         .addEntityClass(University.class)
         .addEntityClass(TopicApplication.class)
-        .addEntityClass(Task.class).build();
+        .addEntityClass(Task.class)
+        .addEntityClass(Activation.class).build();
   }
 
   public static void migrateDatabase() {

--- a/studenthub-portal/src/test/java/cz/studenthub/db/ActivationDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/ActivationDAOTest.java
@@ -1,0 +1,74 @@
+package cz.studenthub.db;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import cz.studenthub.DAOTestSuite;
+import cz.studenthub.core.Activation;
+import cz.studenthub.core.User;
+import io.dropwizard.testing.junit.DAOTestRule;
+
+public class ActivationDAOTest {
+
+  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static ActivationDAO actDAO;
+  private static UserDAO userDAO;
+
+  @BeforeClass
+  public static void setUp() {
+    actDAO = new ActivationDAO(DATABASE.getSessionFactory());
+    userDAO = new UserDAO(DATABASE.getSessionFactory());
+  }
+
+  @Test
+  public void createActivation() {
+    DAOTestSuite.inRollbackTransaction(() -> {
+      User user = userDAO.findById((long) 1);
+      Activation act = new Activation(user);
+
+      Activation created = actDAO.create(act);
+
+      List<Activation> activations = actDAO.findAll();
+      assertNotNull(created.getId());
+      assertEquals(act, created);
+      assertEquals(3, activations.size());
+    });
+  }
+
+  @Test
+  public void fetchActivation() {
+    Activation act = DATABASE.inTransaction(() -> {
+      return actDAO.findById((long) 1);
+    });
+
+    assertNotNull(act);
+    assertEquals("rep3", act.getActivationCode());
+    assertEquals("rep3", act.getUser().getUsername());
+  }
+
+  @Test
+  public void listAllActivations() {
+    List<Activation> activations = DATABASE.inTransaction(() -> {
+      return actDAO.findAll();
+    });
+    assertNotNull(activations);
+    assertEquals(2, activations.size());
+  }
+
+  @Test
+  public void removeActivation() {
+    DAOTestSuite.inRollbackTransaction(() -> {
+      Activation activation = actDAO.findById((long) 2);
+
+      actDAO.delete(activation);
+      List<Activation> activations = actDAO.findAll();
+      assertNotNull(activation);
+      assertEquals(1, activations.size());
+      assertFalse(activations.contains(activation));
+    });
+  }
+}

--- a/studenthub-portal/src/test/java/cz/studenthub/db/UserDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/UserDAOTest.java
@@ -118,4 +118,24 @@ public class UserDAOTest {
     });
   }
 
+  @Test
+  public void findUserByUsername() {
+    User user = DATABASE.inTransaction(() -> {
+      return userDAO.findByUsername("supervisor1");
+    });
+
+    assertNotNull(user);
+    assertEquals("258 457 987", user.getPhone());
+  }
+
+  @Test
+  public void findUserByEmail() {
+    User user = DATABASE.inTransaction(() -> {
+      return userDAO.findByEmail("admin@example.com");
+    });
+
+    assertNotNull(user);
+    assertEquals("123 456 789", user.getPhone());
+  }
+
 }

--- a/studenthub-portal/src/test/resources/db/DB.md
+++ b/studenthub-portal/src/test/resources/db/DB.md
@@ -60,7 +60,7 @@ Test Database contains these entries:
 
 ## Users
 
-(Password field is not present because it is encoded and irrelevant when testing, password encoding test does not need DB)
+Password field is not present because it is encoded and irrelevant when testing and password encoding test does not need DB
 
 | id  | username           | email                       | name               | phone        | lastLogin      | company | faculty | roles                        | tags                     |
 | --- | ------------------ | --------------------------- | ------------------ | ------------ | -------------- | ------- | ------- | ---------------------------- | ------------------------ | 
@@ -84,6 +84,15 @@ Test Database contains these entries:
 | 18  | rep3               | rep3@example.com            | Rep Three          | 234 156 774  | 27.1.2017      | 7       | ------- | [COMPANY_REP]                | ------------------------ | 
 | 19  | superadmin         | superadmin@example.com      | Super Admin        | 463 147 891  | 5.11.2016      | ------- | ------- | [ALL]                        | ------------------------ |
 
+## Activations
+
+Codes were manually assigned to ease testing
+
+| id  | user  | code       |
+| --- | ----- | ---------- |
+| 1   | 18    | rep3       |
+| 2   | 15    | student4   |
+        
 ## Topics
 
 | id  | title               | enabled | shortAbstract                       | description                | creator | supervisors      | degrees                  | tags                      |

--- a/studenthub-portal/src/test/resources/db/test-data.xml
+++ b/studenthub-portal/src/test/resources/db/test-data.xml
@@ -964,4 +964,16 @@
             <column name="APPLICATION_ID" valueNumeric="6"/>
         </insert>
     </changeSet>
+    <changeSet author="phala (generated)" id="1496737117875-20">
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="ACTIVATIONS">
+            <column name="ID" valueNumeric="1"/>
+            <column name="ACTIVATIONCODE" value="rep3"/>
+            <column name="USER_ID" valueNumeric="18"/>
+        </insert>
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="ACTIVATIONS">
+            <column name="ID" valueNumeric="2"/>
+            <column name="ACTIVATIONCODE" value="student4"/>
+            <column name="USER_ID" valueNumeric="15"/>
+        </insert>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
* Created new domain class Activation, which stores `user` with his assigned `activationCode`.
  *  Also added ActivationDAO and ActivationDAOTest.
* `account/signUp` endpoint now throws exceptions when email or username is taken.
   * Added `findByUsername` query into UserDAO.
* account/resendActivation now throws exception when no activation is active.
   * Should never happen in production, it is there just to be sure.
* Added missing query test for `findByEmail` into UserDAOTest.
* Updated `setPassword.html` template to redirect with correct query parameter.
* Cleaned up scheme migration file.
  * Sequences were removed, because PostgreSQL creates their own and it resulted in duplicates.
  * Renamed companies primary key from `constraint_5` to `companies_pkey`.
  * changeSets ids are now again in order and homogeneous.