### PR TITLE
#26 - Add Validator methods for domain classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,13 @@
     <url>https://github.com/StudentHubCZ/studenthub-portal.git</url>
   </scm>
 
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>  
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -111,7 +118,12 @@
         <artifactId>testng</artifactId>
         <version>${testng.version}</version>
         <scope>test</scope>
-      </dependency>   
+      </dependency>
+      <dependency>
+        <groupId>com.github.alex-shpak</groupId>
+        <artifactId>dropwizard-hk2bundle</artifactId>
+        <version>0.4.1</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/studenthub-portal/api-docs/swagger.json
+++ b/studenthub-portal/api-docs/swagger.json
@@ -2,10 +2,10 @@
 {
     "swagger":"2.0",
     "info":{
-        "version":"1.0-SNAPSHOT",
+        "version":"1.1-SNAPSHOT",
         "title":"studenthub-portal"
     },
-    "host":"localhost:8080/api",
+    "host":"localhost:8080",
     "basePath":"/",
     "schemes":[
         "http"
@@ -88,6 +88,41 @@
                 }
             }
         },
+        "/account/resetPassword":{
+            "post":{
+                "consumes":[
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"email",
+                        "in":"formData",
+                        "required":true
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
         "/account/signUp":{
             "post":{
                 "consumes":[
@@ -120,6 +155,11 @@
                     },
                     "400":{
                         "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "409":{
+                        "description":"Conflict",
                         "headers":{
                         }
                     },
@@ -168,6 +208,11 @@
                     },
                     "403":{
                         "description":"Forbidden",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
                         "headers":{
                         }
                     }
@@ -475,6 +520,9 @@
                     "200":{
                         "description":"OK",
                         "headers":{
+                            "Set-Cookie":{
+                                "type":"string"
+                            }
                         }
                     }
                 }
@@ -694,6 +742,107 @@
                             "type":"array",
                             "items":{
                                 "$ref":"#/definitions/User"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/companies/{id}/plan":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/User"
+                        }
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "$ref":"#/definitions/CompanyPlan"
+                        }
+                    },
+                    "403":{
+                        "description":"Forbidden",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/companies/{id}/projects":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Project"
                             }
                         }
                     },
@@ -940,6 +1089,61 @@
                 }
             }
         },
+        "/faculties/{id}/projects":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Project"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
         "/faculties/{id}/students":{
             "get":{
                 "consumes":[
@@ -1034,6 +1238,703 @@
                             "type":"array",
                             "items":{
                                 "$ref":"#/definitions/User"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/plans":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/CompanyPlan"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    }
+                }
+            },
+            "post":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/CompanyPlan"
+                        }
+                    }
+                ],
+                "responses":{
+                    "201":{
+                        "description":"Created",
+                        "headers":{
+                            "Location":{
+                                "type":"string"
+                            }
+                        },
+                        "schema":{
+                            "$ref":"#/definitions/CompanyPlan"
+                        }
+                    }
+                }
+            }
+        },
+        "/plans/{name}":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"name",
+                        "in":"path",
+                        "required":true
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "$ref":"#/definitions/CompanyPlan"
+                        }
+                    }
+                }
+            },
+            "put":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"name",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/CompanyPlan"
+                        }
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "$ref":"#/definitions/CompanyPlan"
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            },
+            "delete":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"name",
+                        "in":"path",
+                        "required":true
+                    }
+                ],
+                "responses":{
+                    "204":{
+                        "description":"No Content",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Project"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    }
+                }
+            },
+            "post":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/Project"
+                        }
+                    }
+                ],
+                "responses":{
+                    "201":{
+                        "description":"Created",
+                        "headers":{
+                            "Location":{
+                                "type":"string"
+                            }
+                        },
+                        "schema":{
+                            "$ref":"#/definitions/Project"
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "500":{
+                        "description":"Internal Server Error",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects/{id}":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "$ref":"#/definitions/Project"
+                        }
+                    }
+                }
+            },
+            "put":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/Project"
+                        }
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "$ref":"#/definitions/Project"
+                        }
+                    },
+                    "403":{
+                        "description":"Forbidden",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            },
+            "delete":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/User"
+                        }
+                    }
+                ],
+                "responses":{
+                    "204":{
+                        "description":"No Content",
+                        "headers":{
+                        }
+                    },
+                    "403":{
+                        "description":"Forbidden",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects/{id}/applications":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/TopicApplication"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects/{id}/assignTopic/{topicId}":{
+            "put":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"topicId",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/User"
+                        }
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        }
+                    },
+                    "403":{
+                        "description":"Forbidden",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    },
+                    "409":{
+                        "description":"Conflict",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects/{id}/companies":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Company"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects/{id}/creators":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/User"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects/{id}/faculties":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Faculty"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/projects/{id}/topics":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Topic"
                             }
                         }
                     },
@@ -1371,6 +2272,11 @@
                         "headers":{
                         }
                     },
+                    "406":{
+                        "description":"Not Acceptable",
+                        "headers":{
+                        }
+                    },
                     "500":{
                         "description":"Internal Server Error",
                         "headers":{
@@ -1443,6 +2349,14 @@
                         "name":"id",
                         "in":"path",
                         "required":true
+                    },
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "type":"object"
+                        }
                     }
                 ],
                 "responses":{
@@ -1452,6 +2366,11 @@
                         },
                         "schema":{
                             "$ref":"#/definitions/Topic"
+                        }
+                    },
+                    "404":{
+                        "description":"Not Found",
+                        "headers":{
                         }
                     }
                 }
@@ -1495,6 +2414,11 @@
                     },
                     "404":{
                         "description":"Not Found",
+                        "headers":{
+                        }
+                    },
+                    "406":{
+                        "description":"Not Acceptable",
                         "headers":{
                         }
                     }
@@ -1607,6 +2531,56 @@
                         },
                         "schema":{
                             "$ref":"#/definitions/User"
+                        }
+                    }
+                }
+            }
+        },
+        "/topics/{id}/projects":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Project"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
                         }
                     }
                 }
@@ -2142,7 +3116,7 @@
                         "in":"body",
                         "required":true,
                         "schema":{
-                            "$ref":"#/definitions/UpdateUserBean"
+                            "$ref":"#/definitions/User"
                         }
                     }
                 ],
@@ -2262,7 +3236,7 @@
                 }
             }
         },
-        "/users/{id}/leadApplications":{
+        "/users/{id}/ledApplications":{
             "get":{
                 "consumes":[
                     "application/json"
@@ -2372,6 +3346,69 @@
                             "type":"array",
                             "items":{
                                 "$ref":"#/definitions/Topic"
+                            }
+                        }
+                    },
+                    "400":{
+                        "description":"Bad Request",
+                        "headers":{
+                        }
+                    },
+                    "403":{
+                        "description":"Forbidden",
+                        "headers":{
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{id}/projects":{
+            "get":{
+                "consumes":[
+                    "application/json"
+                ],
+                "produces":[
+                    "application/json"
+                ],
+                "parameters":[
+                    {
+                        "type":"string",
+                        "name":"id",
+                        "in":"path",
+                        "required":true
+                    },
+                    {
+                        "type":"string",
+                        "name":"size",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "type":"string",
+                        "name":"start",
+                        "in":"query",
+                        "required":false,
+                        "default":"0"
+                    },
+                    {
+                        "name":"body",
+                        "in":"body",
+                        "required":true,
+                        "schema":{
+                            "$ref":"#/definitions/User"
+                        }
+                    }
+                ],
+                "responses":{
+                    "200":{
+                        "description":"OK",
+                        "headers":{
+                        },
+                        "schema":{
+                            "type":"array",
+                            "items":{
+                                "$ref":"#/definitions/Project"
                             }
                         }
                     },
@@ -2538,12 +3575,7 @@
                     "type":"string"
                 },
                 "plan":{
-                    "type":"string",
-                    "enum":[
-                        "TIER_1",
-                        "TIER_2",
-                        "TIER_3"
-                    ]
+                    "$ref":"#/definitions/CompanyPlan"
                 },
                 "size":{
                     "type":"string",
@@ -2559,6 +3591,19 @@
                 }
             }
         },
+        "CompanyPlan":{
+            "properties":{
+                "description":{
+                    "type":"string"
+                },
+                "maxTopics":{
+                    "type":"integer"
+                },
+                "name":{
+                    "type":"string"
+                }
+            }
+        },
         "Faculty":{
             "properties":{
                 "id":{
@@ -2569,6 +3614,43 @@
                 },
                 "university":{
                     "$ref":"#/definitions/University"
+                }
+            }
+        },
+        "Project":{
+            "properties":{
+                "companies":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"#/definitions/Company"
+                    }
+                },
+                "creators":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"#/definitions/User"
+                    }
+                },
+                "description":{
+                    "type":"string"
+                },
+                "faculties":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"#/definitions/Faculty"
+                    }
+                },
+                "id":{
+                    "type":"integer"
+                },
+                "name":{
+                    "type":"string"
+                },
+                "topics":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"#/definitions/Topic"
+                    }
                 }
             }
         },
@@ -2593,6 +3675,15 @@
         },
         "Topic":{
             "properties":{
+                "academicSupervisors":{
+                    "type":"array",
+                    "items":{
+                        "$ref":"#/definitions/User"
+                    }
+                },
+                "creator":{
+                    "$ref":"#/definitions/User"
+                },
                 "degrees":{
                     "type":"string",
                     "enum":[
@@ -2605,8 +3696,17 @@
                 "description":{
                     "type":"string"
                 },
+                "enabled":{
+                    "type":"boolean"
+                },
                 "id":{
                     "type":"integer"
+                },
+                "secondaryDescription":{
+                    "type":"string"
+                },
+                "secondaryTitle":{
+                    "type":"string"
                 },
                 "shortAbstract":{
                     "type":"string"
@@ -2710,47 +3810,6 @@
                 }
             }
         },
-        "UpdateUserBean":{
-            "properties":{
-                "company":{
-                    "$ref":"#/definitions/Company"
-                },
-                "email":{
-                    "type":"string"
-                },
-                "faculty":{
-                    "$ref":"#/definitions/Faculty"
-                },
-                "lastLogin":{
-                    "type":"object"
-                },
-                "name":{
-                    "type":"string"
-                },
-                "phone":{
-                    "type":"string"
-                },
-                "roles":{
-                    "type":"string",
-                    "enum":[
-                        "AC_SUPERVISOR",
-                        "ADMIN",
-                        "COMPANY_REP",
-                        "STUDENT",
-                        "TECH_LEADER"
-                    ]
-                },
-                "tags":{
-                    "type":"array",
-                    "items":{
-                        "type":"string"
-                    }
-                },
-                "username":{
-                    "type":"string"
-                }
-            }
-        },
         "User":{
             "properties":{
                 "company":{
@@ -2780,6 +3839,7 @@
                         "AC_SUPERVISOR",
                         "ADMIN",
                         "COMPANY_REP",
+                        "PROJECT_LEADER",
                         "STUDENT",
                         "TECH_LEADER"
                     ]

--- a/studenthub-portal/initial-data.xml
+++ b/studenthub-portal/initial-data.xml
@@ -48,8 +48,8 @@
             <column name="password" value="$6$utr8Ibd0$83l4Rv.4m4QCdNy4jt5aDO9fC8mYpG6.Z3zPD.6azhSto6lfyNAIcJkE8cg2jjDhKDsiSdLrSkCTLo/xglEzi."/>
             <column name="phone" value="463 147 891"/>
             <column name="username" value="admin"/>
-            <column name="company_id"/>
-            <column name="faculty_id"/>
+            <column name="company_id" valueNumeric="1"/>
+            <column name="faculty_id" valueNumeric="1"/>
         </insert>
         <insert catalogName="studenthub" schemaName="public" tableName="users">
             <column name="id" valueNumeric="2"/>

--- a/studenthub-portal/pom.xml
+++ b/studenthub-portal/pom.xml
@@ -109,6 +109,10 @@
 	  <artifactId>greenmail</artifactId>
 	  <scope>test</scope>
 	</dependency>
+    <dependency>
+      <groupId>com.github.alex-shpak</groupId>
+      <artifactId>dropwizard-hk2bundle</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/studenthub-portal/src/main/java/cz/studenthub/api/DAOBinder.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/api/DAOBinder.java
@@ -1,0 +1,39 @@
+package cz.studenthub.api;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.hibernate.SessionFactory;
+
+import cz.studenthub.db.ActivationDAO;
+import cz.studenthub.db.CompanyDAO;
+import cz.studenthub.db.CompanyPlanDAO;
+import cz.studenthub.db.FacultyDAO;
+import cz.studenthub.db.ProjectDAO;
+import cz.studenthub.db.TaskDAO;
+import cz.studenthub.db.TopicApplicationDAO;
+import cz.studenthub.db.TopicDAO;
+import cz.studenthub.db.UniversityDAO;
+import cz.studenthub.db.UserDAO;
+
+public class DAOBinder extends AbstractBinder {
+
+  private SessionFactory factory;
+
+  public DAOBinder(SessionFactory factory) {
+    this.factory = factory;
+  }
+
+  @Override
+  protected void configure() {
+    bind(new TopicDAO(factory)).to(TopicDAO.class);
+    bind(new CompanyDAO(factory)).to(CompanyDAO.class);
+    bind(new FacultyDAO(factory)).to(FacultyDAO.class);
+    bind(new UniversityDAO(factory)).to(UniversityDAO.class);
+    bind(new CompanyPlanDAO(factory)).to(CompanyPlanDAO.class);
+    bind(new UserDAO(factory)).to(UserDAO.class);
+    bind(new TaskDAO(factory)).to(TaskDAO.class);
+    bind(new TopicApplicationDAO(factory)).to(TopicApplicationDAO.class);
+    bind(new ActivationDAO(factory)).to(ActivationDAO.class);
+    bind(new ProjectDAO(factory)).to(ProjectDAO.class);
+  }
+  
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/core/Project.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/Project.java
@@ -1,5 +1,6 @@
 package cz.studenthub.core;
 
+import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.Entity;
@@ -12,6 +13,9 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
 import org.hibernate.validator.constraints.NotEmpty;
+
+import cz.studenthub.validators.annotations.Role;
+import cz.studenthub.validators.groups.CreateUpdateChecks;
 
 @Entity
 @Table(name = "Projects")
@@ -32,6 +36,7 @@ public class Project {
 
   @NotEmpty
   @ManyToMany
+  @Role(role = UserRole.PROJECT_LEADER, groups = CreateUpdateChecks.class)
   private Set<User> creators;
 
   @ManyToMany
@@ -111,4 +116,27 @@ public class Project {
   public void setTopics(Set<Topic> topics) {
     this.topics = topics;
   }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, description);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if ((obj == null) || (getClass() != obj.getClass())) {
+      return false;
+    }
+
+    return Integer.compare(this.hashCode(), obj.hashCode()) == 0;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Project[id=%s, name=%s]", id, name);
+  }
+
 }

--- a/studenthub-portal/src/main/java/cz/studenthub/core/Topic.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/Topic.java
@@ -35,6 +35,10 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotEmpty;
 
+
+import cz.studenthub.validators.annotations.Role;
+import cz.studenthub.validators.groups.CreateUpdateChecks;
+
 @Entity
 @Table(name = "Topics")
 @NamedQueries({ @NamedQuery(name = "Topic.findAll", query = "SELECT topic FROM Topic topic"),
@@ -59,10 +63,12 @@ public class Topic {
 
   @NotNull
   @ManyToOne(fetch = FetchType.EAGER)
+  @Role(role = UserRole.TECH_LEADER, groups = CreateUpdateChecks.class)
   private User creator;
 
   @Nullable
   @ManyToMany
+  @Role(role = UserRole.AC_SUPERVISOR, groups = CreateUpdateChecks.class)
   private Set<User> academicSupervisors;
 
   @ElementCollection(fetch = FetchType.EAGER)
@@ -200,4 +206,5 @@ public class Topic {
   public String toString() {
     return String.format("Topic[id=%s, title=%s]", id, title);
   }
+
 }

--- a/studenthub-portal/src/main/java/cz/studenthub/core/TopicApplication.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/TopicApplication.java
@@ -35,6 +35,9 @@ import javax.validation.constraints.NotNull;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import cz.studenthub.validators.annotations.Role;
+import cz.studenthub.validators.groups.CreateUpdateChecks;
+
 @Entity
 @Table(name = "TopicApplications")
 @NamedQueries({ @NamedQuery(name = "TopicApplication.findAll", query = "SELECT app FROM TopicApplication app"),
@@ -73,13 +76,16 @@ public class TopicApplication {
   private Faculty faculty;
 
   @ManyToOne
+  @Role(role = UserRole.TECH_LEADER, groups = CreateUpdateChecks.class)
   private User techLeader;
 
   @NotNull
   @ManyToOne
+  @Role(role = UserRole.STUDENT, groups = CreateUpdateChecks.class)
   private User student;
 
   @ManyToOne
+  @Role(role = UserRole.AC_SUPERVISOR, groups = CreateUpdateChecks.class)
   private User academicSupervisor;
 
   public TopicApplication() {
@@ -208,4 +214,5 @@ public class TopicApplication {
   public String toString() {
     return String.format("TopicApplication[id=%s]", id);
   }
+
 }

--- a/studenthub-portal/src/main/java/cz/studenthub/health/StudentHubHealthCheck.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/health/StudentHubHealthCheck.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package cz.studenthub.health;
 
+import javax.inject.Inject;
+
 import com.codahale.metrics.health.HealthCheck;
 
 import cz.studenthub.core.UserRole;
@@ -30,11 +32,8 @@ import io.dropwizard.hibernate.UnitOfWork;
  */
 public class StudentHubHealthCheck extends HealthCheck {
 
+  @Inject
   private UserDAO userDao;
-  
-  public StudentHubHealthCheck(UserDAO userDao) {
-    this.userDao = userDao;
-  }
   
   @UnitOfWork
   @Override

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/CompanyPlanResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/CompanyPlanResource.java
@@ -19,6 +19,7 @@ package cz.studenthub.resources;
 import java.util.List;
 
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -52,11 +53,8 @@ import io.dropwizard.jersey.params.IntParam;
 @Consumes(MediaType.APPLICATION_JSON)
 public class CompanyPlanResource {
 
-  private final CompanyPlanDAO cpDao;
-
-  public CompanyPlanResource(CompanyPlanDAO cpDao) {
-    this.cpDao = cpDao;
-  }
+  @Inject
+  private CompanyPlanDAO cpDao;
 
   @GET
   @Timed

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/CompanyResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/CompanyResource.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -63,17 +64,18 @@ import io.dropwizard.jersey.params.LongParam;
 @Consumes(MediaType.APPLICATION_JSON)
 public class CompanyResource {
 
-  private final CompanyDAO companyDao;
-  private final UserDAO userDao;
-  private final TopicDAO topicDao;
-  private final ProjectDAO projectDao;
 
-  public CompanyResource(CompanyDAO companyDao, UserDAO userDao, TopicDAO topicDao, ProjectDAO projectDao) {
-    this.companyDao = companyDao;
-    this.userDao = userDao;
-    this.topicDao = topicDao;
-    this.projectDao = projectDao;
-  }
+  @Inject
+  private CompanyDAO companyDao;
+
+  @Inject
+  private UserDAO userDao;
+
+  @Inject
+  private TopicDAO topicDao;
+
+  @Inject
+  private ProjectDAO projectDao;
 
   @GET
   @Timed

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/FacultyResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/FacultyResource.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -59,15 +60,14 @@ import io.dropwizard.jersey.params.LongParam;
 @Consumes(MediaType.APPLICATION_JSON)
 public class FacultyResource {
 
-  private final FacultyDAO facDao;
-  private final UserDAO userDao;
-  private final ProjectDAO projectDao;
+  @Inject
+  private FacultyDAO facDao;
 
-  public FacultyResource(FacultyDAO facDao, UserDAO userDao, ProjectDAO projectDao) {
-    this.facDao = facDao;
-    this.userDao = userDao;
-    this.projectDao = projectDao;
-  }
+  @Inject
+  private UserDAO userDao;
+
+  @Inject
+  private ProjectDAO projectDao;
 
   @GET
   @UnitOfWork

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/LoginResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/LoginResource.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.Set;
 
 import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
@@ -83,10 +84,10 @@ public class LoginResource {
   
   private final String jwtSecret;
   
-  private final UserDAO userDao;
+  @Inject
+  private UserDAO userDao;
 
-  public LoginResource(UserDAO userDao, String jwtSecret) {
-    this.userDao = userDao;
+  public LoginResource(String jwtSecret) {
     this.jwtSecret = jwtSecret;
   }
 

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/ProjectResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/ProjectResource.java
@@ -19,6 +19,7 @@ package cz.studenthub.resources;
 import java.util.List;
 
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -52,25 +53,26 @@ import cz.studenthub.db.ProjectDAO;
 import cz.studenthub.db.TopicApplicationDAO;
 import cz.studenthub.db.TopicDAO;
 import cz.studenthub.util.PagingUtil;
+import cz.studenthub.validators.groups.CreateUpdateChecks;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.jersey.params.LongParam;
+import io.dropwizard.validation.Validated;
 
 @Path("/projects")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ProjectResource {
 
-  private final ProjectDAO projectDao;
-  private final TopicApplicationDAO appDao;
-  private final TopicDAO topicDao;
+  @Inject
+  private ProjectDAO projectDao;
 
-  public ProjectResource(ProjectDAO projectDao, TopicApplicationDAO appDao, TopicDAO topicDao) {
-    this.projectDao = projectDao;
-    this.appDao = appDao;
-    this.topicDao = topicDao;
-  }
+  @Inject
+  private TopicApplicationDAO appDao;
+
+  @Inject
+  private TopicDAO topicDao;
 
   @GET
   @Timed
@@ -91,7 +93,7 @@ public class ProjectResource {
   @ExceptionMetered
   @UnitOfWork
   @RolesAllowed({"ADMIN", "PROJECT_LEADER"})
-  public Response create(@NotNull @Valid Project project, @Auth User user) {
+  public Response create(@NotNull @Valid @Validated(CreateUpdateChecks.class) Project project, @Auth User user) {
 
     // If user is creator or admin
     if (project.getCreators().contains(user) || user.getRoles().contains(UserRole.ADMIN)) {
@@ -112,7 +114,7 @@ public class ProjectResource {
   @Path("/{id}")
   @UnitOfWork
   @RolesAllowed({"ADMIN", "PROJECT_LEADER"})
-  public Response update(@PathParam("id") LongParam idParam, @NotNull @Valid Project project, @Auth User user) {
+  public Response update(@PathParam("id") LongParam idParam, @NotNull @Valid @Validated(CreateUpdateChecks.class) Project project, @Auth User user) {
     Long id = idParam.get();
     Project oldProject = projectDao.findById(id);
     if (oldProject == null) 

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/RegistrationResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/RegistrationResource.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -61,12 +62,14 @@ import io.dropwizard.jersey.params.LongParam;
 public class RegistrationResource {
 
   private final MailClient mailer;
-  private final UserDAO userDao;
-  private final ActivationDAO actDao;
 
-  public RegistrationResource(UserDAO userDao, ActivationDAO actDao, SmtpConfig smtpConfig) {
-    this.userDao = userDao;
-    this.actDao = actDao;
+  @Inject
+  private UserDAO userDao;
+
+  @Inject
+  private ActivationDAO actDao;
+
+  public RegistrationResource(SmtpConfig smtpConfig) {
     this.mailer = new MailClient(smtpConfig);
   }
 
@@ -88,10 +91,6 @@ public class RegistrationResource {
     // check if someone is not trying to reg as ADMIN
     if (user.getRoles().contains(UserRole.ADMIN))
       throw new WebApplicationException("Invalid role - can't register new ADMIN.", Status.BAD_REQUEST);
-
-    // check either faculty or company is assigned
-    if (user.getFaculty() == null && user.getCompany() == null)
-      throw new WebApplicationException("User must have either Faculty of Company assigned.", Status.BAD_REQUEST);
 
     // persist user to DB
     userDao.create(user);

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/TagResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/TagResource.java
@@ -19,6 +19,7 @@ package cz.studenthub.resources;
 import java.util.List;
 
 import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
 import javax.validation.constraints.Min;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -42,13 +43,11 @@ import io.dropwizard.jersey.params.IntParam;
 @Produces(MediaType.APPLICATION_JSON)
 public class TagResource {
 
-  private final UserDAO userDao;
-  private final TopicDAO topicDao;
+  @Inject
+  private UserDAO userDao;
 
-  public TagResource(UserDAO userDao, TopicDAO topicDao) {
-    this.userDao = userDao;
-    this.topicDao = topicDao;
-  }
+  @Inject
+  private TopicDAO topicDao;
 
   @GET
   @Timed

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/TaskResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/TaskResource.java
@@ -17,6 +17,7 @@
 package cz.studenthub.resources;
 
 import javax.annotation.security.PermitAll;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -51,13 +52,11 @@ import io.dropwizard.jersey.params.LongParam;
 @PermitAll
 public class TaskResource {
 
-  private final TopicApplicationDAO appDao;
-  private final TaskDAO taskDao;
+  @Inject
+  private TopicApplicationDAO appDao;
 
-  public TaskResource(TopicApplicationDAO appDao, TaskDAO taskDao) {
-    this.appDao = appDao;
-    this.taskDao = taskDao;
-  }
+  @Inject
+  private TaskDAO taskDao;
 
   @GET
   @Path("/{id}")

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/TopicApplicationResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/TopicApplicationResource.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -49,23 +50,23 @@ import cz.studenthub.core.UserRole;
 import cz.studenthub.db.TaskDAO;
 import cz.studenthub.db.TopicApplicationDAO;
 import cz.studenthub.util.PagingUtil;
+import cz.studenthub.validators.groups.CreateUpdateChecks;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.jersey.params.LongParam;
+import io.dropwizard.validation.Validated;
 
 @Path("/applications")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class TopicApplicationResource {
 
-  private final TopicApplicationDAO appDao;
-  private final TaskDAO taskDao;
+  @Inject
+  private TopicApplicationDAO appDao;
 
-  public TopicApplicationResource(TopicApplicationDAO appDao, TaskDAO taskDao) {
-    this.appDao = appDao;
-    this.taskDao = taskDao;
-  }
+  @Inject
+  private TaskDAO taskDao;
 
   @GET
   @Timed
@@ -103,7 +104,7 @@ public class TopicApplicationResource {
   @ExceptionMetered
   @Path("/{id}")
   @UnitOfWork
-  public Response update(@PathParam("id") LongParam idParam, @NotNull @Valid TopicApplication app, @Auth User user) {
+  public Response update(@PathParam("id") LongParam idParam, @NotNull @Valid @Validated(CreateUpdateChecks.class) TopicApplication app, @Auth User user) {
     
     long id = idParam.get();
     TopicApplication oldApp = appDao.findById(id);
@@ -127,7 +128,7 @@ public class TopicApplicationResource {
   @ExceptionMetered
   @UnitOfWork
   @RolesAllowed("STUDENT")
-  public Response create(@NotNull @Valid TopicApplication app) {
+  public Response create(@NotNull @Valid @Validated(CreateUpdateChecks.class) TopicApplication app) {
     appDao.create(app);
     if (app.getId() == null)
       throw new WebApplicationException(Status.INTERNAL_SERVER_ERROR);

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/TopicResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/TopicResource.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -53,27 +54,29 @@ import cz.studenthub.db.TopicApplicationDAO;
 import cz.studenthub.db.TopicDAO;
 import cz.studenthub.db.UserDAO;
 import cz.studenthub.util.PagingUtil;
+import cz.studenthub.validators.groups.CreateUpdateChecks;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.dropwizard.jersey.params.IntParam;
 import io.dropwizard.jersey.params.LongParam;
+import io.dropwizard.validation.Validated;
 
 @Path("/topics")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class TopicResource {
 
-  private final TopicDAO topicDao;
-  private final TopicApplicationDAO appDao;
-  private final UserDAO userDao;
-  private final ProjectDAO projectDao;
+  @Inject
+  private TopicDAO topicDao;
 
-  public TopicResource(TopicDAO topicDao, TopicApplicationDAO taDao, UserDAO userDao, ProjectDAO projectDao) {
-    this.topicDao = topicDao;
-    this.appDao = taDao;
-    this.userDao = userDao;
-    this.projectDao = projectDao;
-  }
+  @Inject
+  private TopicApplicationDAO appDao;
+
+  @Inject
+  private UserDAO userDao;
+
+  @Inject
+  private ProjectDAO projectDao;
 
   @GET
   @Timed
@@ -118,7 +121,7 @@ public class TopicResource {
   @Path("/{id}")
   @UnitOfWork
   @RolesAllowed({"ADMIN", "TECH_LEADER"})
-  public Response update(@PathParam("id") LongParam idParam, @NotNull @Valid Topic topic, @Auth User user) {
+  public Response update(@PathParam("id") LongParam idParam, @NotNull @Valid @Validated(CreateUpdateChecks.class) Topic topic, @Auth User user) {
 
     Long id = idParam.get();
     Topic oldTopic = topicDao.findById(id);
@@ -154,7 +157,7 @@ public class TopicResource {
   @ExceptionMetered
   @UnitOfWork
   @RolesAllowed({ "ADMIN", "TECH_LEADER" })
-  public Response create(@NotNull @Valid Topic topic, @Auth User user) {
+  public Response create(@NotNull @Valid @Validated(CreateUpdateChecks.class) Topic topic, @Auth User user) {
 
     // If user is topic creator or is an admin
     if (topic.getCreator().getId().equals(user.getId()) || user.getRoles().contains(UserRole.ADMIN)) {

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/UniversityResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/UniversityResource.java
@@ -19,6 +19,7 @@ package cz.studenthub.resources;
 import java.util.List;
 
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -55,13 +56,11 @@ import io.dropwizard.jersey.params.LongParam;
 @Consumes(MediaType.APPLICATION_JSON)
 public class UniversityResource {
 
-  private final UniversityDAO uniDao;
-  private final FacultyDAO facDao;
+  @Inject
+  private UniversityDAO uniDao;
 
-  public UniversityResource(UniversityDAO uniDao, FacultyDAO facDao) {
-    this.uniDao = uniDao;
-    this.facDao = facDao;
-  }
+  @Inject
+  private FacultyDAO facDao;
 
   @GET
   @UnitOfWork

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/UserResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/UserResource.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -60,20 +61,20 @@ import io.dropwizard.jersey.params.LongParam;
 @Consumes(MediaType.APPLICATION_JSON)
 public class UserResource {
 
-  private final UserDAO userDao;
-  private final TopicApplicationDAO appDao;
-  private final TopicDAO topicDao;
-  private final ProjectDAO projectDao;
+  @Inject
+  private UserDAO userDao;
+
+  @Inject
+  private TopicApplicationDAO appDao;
+
+  @Inject
+  private TopicDAO topicDao;
+
+  @Inject
+  private ProjectDAO projectDao;
 
   // private static final Logger LOG =
   // LoggerFactory.getLogger(UserResource.class);
-
-  public UserResource(UserDAO userDao, TopicDAO topicDao, TopicApplicationDAO taDao, ProjectDAO projectDao) {
-    this.userDao = userDao;
-    this.appDao = taDao;
-    this.topicDao = topicDao;
-    this.projectDao = projectDao;
-  }
 
   @GET
   @Timed

--- a/studenthub-portal/src/main/java/cz/studenthub/validators/RoleValidator.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/validators/RoleValidator.java
@@ -1,0 +1,38 @@
+package cz.studenthub.validators;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import cz.studenthub.core.User;
+import cz.studenthub.db.UserDAO;
+import cz.studenthub.validators.annotations.Role;
+
+/**
+ * This validator checks if required User has required UserRole
+ */
+public class RoleValidator implements ConstraintValidator<Role, User> {
+
+  private Role check;
+
+  @Inject
+  private UserDAO userDao;
+
+  @Override
+  public void initialize(Role check) {
+    this.check = check;    
+  }
+
+  @Override
+  public boolean isValid(User user, ConstraintValidatorContext arg1) {
+    // Will not validate null, if field cannot be null it will be annotated with @NotNull
+    if (user != null) {
+      user = userDao.findById(user.getId());
+      if (user == null)
+        return false;
+
+      return user.getRoles().contains(check.role());
+    }
+    return true;
+  }
+
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/validators/SetRoleValidator.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/validators/SetRoleValidator.java
@@ -1,0 +1,45 @@
+package cz.studenthub.validators;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraints.NotNull;
+
+import cz.studenthub.core.User;
+import cz.studenthub.db.UserDAO;
+import cz.studenthub.validators.annotations.Role;
+
+/**
+ * This validator checks if required Set of Users has required UserRole, will not be needed in Hibernate Validator 6
+ */
+public class SetRoleValidator implements ConstraintValidator<Role, Set<User>> {
+
+  private Role check;
+
+  @Inject
+  private UserDAO userDao;
+
+  @Override
+  public void initialize(Role check) {
+    this.check = check;    
+  }
+
+  @Override
+  public boolean isValid(@NotNull Set<User> users, ConstraintValidatorContext arg1) {
+    // Will not validate null, if field cannot be null it will be annotated with @NotNull
+    if (users != null) {
+      for (User user : users) {
+        user = userDao.findById(user.getId());
+        if (user == null)
+          return false;
+
+        if (!user.getRoles().contains(check.role()))
+          return false;
+      }
+    }
+    return true;
+  }  
+
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/validators/annotations/Role.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/validators/annotations/Role.java
@@ -1,0 +1,35 @@
+package cz.studenthub.validators.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import cz.studenthub.core.UserRole;
+import cz.studenthub.validators.RoleValidator;
+import cz.studenthub.validators.SetRoleValidator;
+
+/**
+ * Annotation for checking required roles
+ */
+@Constraint(validatedBy = {RoleValidator.class, SetRoleValidator.class})
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER, TYPE_PARAMETER, TYPE, TYPE_USE })
+public @interface Role {
+
+  String message() default "doesn't have required role {role}";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  UserRole role() default UserRole.ADMIN;
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/validators/groups/CreateUpdateChecks.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/validators/groups/CreateUpdateChecks.java
@@ -1,0 +1,9 @@
+package cz.studenthub.validators.groups;
+
+import javax.validation.groups.Default;
+
+/*
+ * Validation group which is run only on create or update requests
+ */
+public interface CreateUpdateChecks extends Default {
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/validators/groups/NotNullChecks.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/validators/groups/NotNullChecks.java
@@ -1,0 +1,7 @@
+package cz.studenthub.validators.groups;
+
+/*
+ * Group for checking null constraints first
+ */
+public interface NotNullChecks {
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/validators/groups/ValidationMethodChecks.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/validators/groups/ValidationMethodChecks.java
@@ -1,0 +1,7 @@
+package cz.studenthub.validators.groups;
+
+/*
+ * Group of all ValidationMethods
+ */
+public interface ValidationMethodChecks {
+}

--- a/studenthub-portal/src/main/resources/db/InitialData.md
+++ b/studenthub-portal/src/main/resources/db/InitialData.md
@@ -32,7 +32,7 @@ All users have password "test".
 
 | id  | username           | email                       | name               | phone        | lastLogin      | company | faculty | roles                        | tags                     |
 | --- | ------------------ | --------------------------- | ------------------ | ------------ | -------------- | ------- | ------- | ---------------------------- | ------------------------ | 
-| 1   | superadmin         | superadmin@example.com      | Admin Admin        | 463 147 891  | 5.11.2016      | ------- | ------- | [ALL]                        | ------------------------ |
+| 1   | superadmin         | superadmin@example.com      | Admin Admin        | 463 147 891  | 5.11.2016      | 1       | 1       | [ALL]                        | ------------------------ |
 | 2   | supervisor         | supervisor@example.com      | Supervisor One     | 258 457 987  | 19.3.2017      | ------- | 1       | [SUPERVISOR]                 | [Java,Ruby,MU]           |
 | 3   | leader             | leader@example.com          | Leader One         | 875 687 149  | 9.1.2017       | 1       | ------- | [LEADER]                     | [C++, Oracle, Ruby ]     |
 | 4   | student            | student@example.com         | Student One        | 654 712 354  | 26.8.2016      | ------- | 1       | [STUDENT]                    | [MU, JavaScript, React]  |

--- a/studenthub-portal/src/test/java/cz/studenthub/db/UserDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/UserDAOTest.java
@@ -91,7 +91,7 @@ public class UserDAOTest {
       return userDAO.findByCompany(company);
     });
     assertNotNull(users);
-    assertEquals(2, users.size());
+    assertEquals(3, users.size());
   }
 
   @Test
@@ -112,9 +112,9 @@ public class UserDAOTest {
       List<User> supervisors = userDAO.findByRoleAndFaculty(UserRole.AC_SUPERVISOR, faculty);
 
       assertNotNull(students);
-      assertEquals(2, students.size());
+      assertEquals(3, students.size());
       assertNotNull(supervisors);
-      assertEquals(1, supervisors.size());
+      assertEquals(2, supervisors.size());
     });
   }
 

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyResourceTest.java
@@ -57,7 +57,7 @@ public class CompanyResourceTest {
     assertEquals(company.getName(), "Company Five");
   }
 
-  @Test(dependsOnMethods = "listCompanies")
+  @Test(dependsOnMethods = "listCompanies", dependsOnGroups = "login")
   public void createCompany() {
     JSONObject plan = new JSONObject();
     plan.put("name", "TIER_1");

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/FacultyResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/FacultyResourceTest.java
@@ -104,7 +104,7 @@ public class FacultyResourceTest {
         .request(MediaType.APPLICATION_JSON), client).get(new GenericType<List<User>>(){});
 
     assertNotNull(users);
-    assertEquals(users.size(), 2);
+    assertEquals(users.size(), 3);
   }
 
   @Test(dependsOnGroups = "login")

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/ProjectResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/ProjectResourceTest.java
@@ -37,8 +37,8 @@ public class ProjectResourceTest {
   }
   
   private List<Project> fetchProjects() {
-    return IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/projects", dropwizard.getLocalPort()))
-      .request(), client).get(new GenericType<List<Project>>(){});
+    return client.target(String.format("http://localhost:%d/api/projects", dropwizard.getLocalPort()))
+      .request().get(new GenericType<List<Project>>(){});
   }
 
   @Test(dependsOnGroups = "migrate")
@@ -59,10 +59,10 @@ public class ProjectResourceTest {
     assertEquals(topic.getName(), "Industry things");
   }
 
-  @Test(dependsOnMethods = "listProjects")
+  @Test(dependsOnMethods = "listProjects", dependsOnGroups = "login")
   public void createProject() {
     JSONObject creator = new JSONObject();
-    creator.put("id", 11);
+    creator.put("id", 20);
 
     JSONArray creators = new JSONArray();
     creators.add(creator);
@@ -83,7 +83,7 @@ public class ProjectResourceTest {
   @Test(dependsOnMethods = "createProject")
   public void updateProject() {
     JSONObject creator = new JSONObject();
-    creator.put("id", 11);
+    creator.put("id", 20);
 
     JSONArray creators = new JSONArray();
     creators.add(creator);
@@ -110,7 +110,7 @@ public class ProjectResourceTest {
     assertEquals(fetchProjects().size(), 2);
   }
 
-  @Test(dependsOnGroups = {"migrate", "fetchTopic", "fetchProject"})
+  @Test(dependsOnGroups = {"login", "fetchTopic", "fetchProject"})
   public void assignTopic() {
     Topic topic = client.target(String.format("http://localhost:%d/api/topics/3", dropwizard.getLocalPort())).request().get(Topic.class);
 

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/UniversityResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/UniversityResourceTest.java
@@ -53,7 +53,7 @@ public class UniversityResourceTest {
     assertEquals(uni.getName(), "Masaryk University");
   }
 
-  @Test(dependsOnMethods = "listUniversities")
+  @Test(dependsOnMethods = "listUniversities", dependsOnGroups = "login")
   public void createUniversity() {
     JSONObject university = new JSONObject();
     university.put("name", "Unknown");

--- a/studenthub-portal/src/test/resources/db/DB.md
+++ b/studenthub-portal/src/test/resources/db/DB.md
@@ -93,7 +93,7 @@ Password field is not present because it is encoded and irrelevant when testing 
 | 16  | rep1               | rep1@example.com            | Rep One            | 154 798 416  | 6.5.2016       | 1       | ------- | [COMPANY_REP]                | ------------------------ |
 | 17  | rep2               | rep2@example.com            | Rep Two            | 871 423 698  | 27.4.2016      | 8       | ------- | [COMPANY_REP]                | ------------------------ | 
 | 18  | rep3               | rep3@example.com            | Rep Three          | 234 156 774  | 27.1.2017      | 7       | ------- | [COMPANY_REP]                | ------------------------ | 
-| 19  | superadmin         | superadmin@example.com      | Super Admin        | 463 147 891  | 5.11.2016      | ------- | ------- | [ALL]                        | ------------------------ |
+| 19  | superadmin         | superadmin@example.com      | Super Admin        | 463 147 891  | 5.11.2016      | 1       | 1       | [ALL]                        | ------------------------ |
 | 20  | project            | project@example.com         | Project Leader     | 205 709 548  | 10.6.2017      | ------- | ------- | [PROJECT_LEADER]             | ------------------------ |
 
 ## Activations

--- a/studenthub-portal/src/test/resources/db/test-data.xml
+++ b/studenthub-portal/src/test/resources/db/test-data.xml
@@ -419,8 +419,8 @@
             <column name="PASSWORD" value="$6$UMtqjjBp$6t7ZYd9I.itX5HCv5xbVftBpAS248VHe241lj8cw6Yfj3JfWbTXNcXwXdGkShO.00UHWqrTXcFCUDAx.xh6FA."/>
             <column name="PHONE" value="463 147 891"/>
             <column name="USERNAME" value="superadmin"/>
-            <column name="COMPANY_ID"/>
-            <column name="FACULTY_ID"/>
+            <column name="COMPANY_ID" valueNumeric="1"/>
+            <column name="FACULTY_ID" valueNumeric="1"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="USERS">
             <column name="ID" valueNumeric="20"/>
@@ -529,6 +529,10 @@
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="USER_ROLES">
             <column name="USER_ID" valueNumeric="19"/>
+            <column name="ROLES" value="PROJECT_LEADER"/>
+        </insert>
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="USER_ROLES">
+            <column name="USER_ID" valueNumeric="20"/>
             <column name="ROLES" value="PROJECT_LEADER"/>
         </insert>
     </changeSet>


### PR DESCRIPTION
* Currently I am checking if these statements are true. This changes can invalidate previous data:
   * Topic:
       * `creator` must be `TECH_LEADER`.
       * All `academicSupervisor` must be `AC_SUPERVISOR`.
   * TopicApplication:
       * `techLeader` must be `TECH_LEADER`.
       * `student` must be `STUDENT`.
       * `academicSupervisor` must be `AC_SUPERVISOR`.
    * User:
       * If user is `STUDENT` or `AC_SUPERVISOR` he must have specified `faculty`.
       * If user is `TECH_LEADER` or `COMPANY_REP` he must have specified `company`.
    * Project:
       * All `creators` must be `PROJECT_LEADER`. 
* Validation in `User` is ordered to prevent NullPointerExceptions.
* Configured HK2 to automatically inject DAO classes.
   * Used this [HK2 Bundle](https://github.com/alex-shpak/dropwizard-hk2bundle).
   * All Resources and Validators now use DI injected DAO classes. 
   * Only Authorizers are not automatically injected because of UnitOfAwareProxyFactory.
* Added `@Role` annotation for checking required roles.
   * Validated by `RoleValidator` and `SetRoleValidator` for checking individual user and set of users, respectively.
      * These validators **always** fetch User from DB.
   * This validation is only done on _create_ and _update_ endpoints.
* Updated Swagger documentation.
* Another round of dependency fixes to IntegrationTests.