### PR TITLE
#96 - CompanyPlan is now configurable

### DIFF
--- a/studenthub-portal/initial-data.xml
+++ b/studenthub-portal/initial-data.xml
@@ -1,5 +1,12 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="phala (generated)" id="1496646751908-29">
+        <insert catalogName="studenthub" schemaName="public" tableName="plans">
+            <column name="maxtopics" valueNumeric="3"/>
+            <column name="name" value="TIER_1"/>
+            <column name="description" value="For basic use"/>
+        </insert>
+    </changeSet>
     <changeSet author="phala (generated)" id="1496646751908-13">
         <insert catalogName="studenthub" schemaName="public" tableName="companies">
             <column name="id" valueNumeric="1"/>
@@ -7,7 +14,7 @@
             <column name="country" value="CZ"/>
             <column name="logourl" value="c1.com/logo.png"/>
             <column name="name" value="Company One"/>
-            <column name="plan" value="TIER_3"/>
+            <column name="plan_name" value="TIER_1"/>
             <column name="size" value="CORPORATE"/>
             <column name="url" value="www.c1.com"/>
         </insert>
@@ -106,6 +113,10 @@
         <insert catalogName="studenthub" schemaName="public" tableName="user_roles">
             <column name="user_id" valueNumeric="1"/>
             <column name="roles" value="STUDENT"/>
+        </insert>
+        <insert catalogName="studenthub" schemaName="public" tableName="user_roles">
+            <column name="user_id" valueNumeric="1"/>
+            <column name="roles" value="COMPANY_REP"/>
         </insert>
     </changeSet>
     <changeSet author="phala (generated)" id="1496646751908-19">

--- a/studenthub-portal/src/main/java/cz/studenthub/StudentHubApplication.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/StudentHubApplication.java
@@ -32,6 +32,7 @@ import cz.studenthub.auth.StudentHubAuthorizer;
 import cz.studenthub.auth.TokenAuthenticator;
 import cz.studenthub.core.Activation;
 import cz.studenthub.core.Company;
+import cz.studenthub.core.CompanyPlan;
 import cz.studenthub.core.Faculty;
 import cz.studenthub.core.Task;
 import cz.studenthub.core.Topic;
@@ -40,6 +41,7 @@ import cz.studenthub.core.University;
 import cz.studenthub.core.User;
 import cz.studenthub.db.ActivationDAO;
 import cz.studenthub.db.CompanyDAO;
+import cz.studenthub.db.CompanyPlanDAO;
 import cz.studenthub.db.FacultyDAO;
 import cz.studenthub.db.TaskDAO;
 import cz.studenthub.db.TopicApplicationDAO;
@@ -47,6 +49,7 @@ import cz.studenthub.db.TopicDAO;
 import cz.studenthub.db.UniversityDAO;
 import cz.studenthub.db.UserDAO;
 import cz.studenthub.health.StudentHubHealthCheck;
+import cz.studenthub.resources.CompanyPlanResource;
 import cz.studenthub.resources.CompanyResource;
 import cz.studenthub.resources.FacultyResource;
 import cz.studenthub.resources.LoginResource;
@@ -92,7 +95,8 @@ public class StudentHubApplication extends Application<StudentHubConfiguration> 
    */
   private final HibernateBundle<StudentHubConfiguration> hibernate = new HibernateBundle<StudentHubConfiguration>(
       // list of entities
-      User.class, Topic.class, TopicApplication.class, Company.class, University.class, Faculty.class, Task.class, Activation.class) {
+      User.class, Topic.class, TopicApplication.class, Company.class, University.class, Faculty.class, Task.class,
+      Activation.class, CompanyPlan.class) {
 
     @Override
     public DataSourceFactory getDataSourceFactory(StudentHubConfiguration configuration) {
@@ -142,6 +146,7 @@ public class StudentHubApplication extends Application<StudentHubConfiguration> 
     final TopicApplicationDAO taDao = new TopicApplicationDAO(hibernate.getSessionFactory());
     final TaskDAO taskDao = new TaskDAO(hibernate.getSessionFactory());
     final ActivationDAO actDao = new ActivationDAO(hibernate.getSessionFactory());
+    final CompanyPlanDAO cpDao = new CompanyPlanDAO(hibernate.getSessionFactory());
 
     // enable session manager
     environment.servlets().setSessionHandler(new SessionHandler());
@@ -151,12 +156,13 @@ public class StudentHubApplication extends Application<StudentHubConfiguration> 
     environment.jersey().register(new UniversityResource(uniDao, facDao));
     environment.jersey().register(new FacultyResource(facDao, userDao));
     environment.jersey().register(new UserResource(userDao, topicDao, taDao));
-    environment.jersey().register(new TopicResource(topicDao, taDao));
+    environment.jersey().register(new TopicResource(topicDao, taDao, userDao));
     environment.jersey().register(new TopicApplicationResource(taDao, taskDao));
     environment.jersey().register(new TaskResource(taDao, taskDao));
     environment.jersey().register(new LoginResource(userDao, configuration.getJwtSecret()));
     environment.jersey().register(new RegistrationResource(userDao, actDao, configuration.getSmtpConfig()));
     environment.jersey().register(new TagResource(userDao, topicDao));
+    environment.jersey().register(new CompanyPlanResource(cpDao));
 
     // set up auth
     configureAuth(configuration, environment, userDao);

--- a/studenthub-portal/src/main/java/cz/studenthub/core/Company.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/Company.java
@@ -24,11 +24,16 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
 
 @Entity
 @Table(name = "Companies")
@@ -52,7 +57,9 @@ public class Company {
   @Enumerated(EnumType.STRING)
   private CompanySize size;
 
-  @Enumerated(EnumType.STRING)
+  @ManyToOne
+  @NotNull
+  @JsonProperty(access = Access.WRITE_ONLY)
   private CompanyPlan plan;
 
   public Company() {
@@ -66,6 +73,7 @@ public class Company {
     this.country = country;
     this.logoUrl = logoUrl;
     this.size = size;
+    this.plan = plan;
   }
 
   public Long getId() {

--- a/studenthub-portal/src/main/java/cz/studenthub/core/CompanyPlan.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/CompanyPlan.java
@@ -1,5 +1,85 @@
 package cz.studenthub.core;
 
-public enum CompanyPlan {
-  TIER_1, TIER_2, TIER_3
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+@Entity
+@Table(name = "Plans")
+@NamedQueries({ @NamedQuery(name = "CompanyPlan.findAll", query = "SELECT companyPlan FROM CompanyPlan companyPlan") })
+public class CompanyPlan {
+
+  @Id
+  @Column(name = "name", unique = true)
+  @NotEmpty
+  private String name;
+
+  private String description;
+
+  @NotNull
+  @Min(0)
+  private int maxTopics;
+
+  public CompanyPlan() {
+  }
+
+  public CompanyPlan(String name, int maxTopics) {
+    this.name = name;
+    this.maxTopics = maxTopics;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public int getMaxTopics() {
+    return maxTopics;
+  }
+
+  public void setMaxTopics(int maxTopics) {
+    this.maxTopics = maxTopics;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, maxTopics);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if ((obj == null) || (getClass() != obj.getClass())) {
+      return false;
+    }
+
+    return Integer.compare(this.hashCode(), obj.hashCode()) == 0;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("CompanyPlan[name=%s, maxTopics=%d, description=%s]", name, maxTopics, description);
+  }
 }

--- a/studenthub-portal/src/main/java/cz/studenthub/core/Topic.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/Topic.java
@@ -41,7 +41,8 @@ import org.hibernate.validator.constraints.NotEmpty;
   @NamedQuery(name = "Topic.findByCreator", query = "SELECT topic FROM Topic topic WHERE topic.creator = :creator"),
   @NamedQuery(name = "Topic.findBySupervisor", query = "SELECT topic FROM Topic topic join topic.academicSupervisors supervisor WHERE supervisor = :supervisor"),
   @NamedQuery(name = "Topic.findByTag", query = "SELECT topic FROM Topic topic join topic.tags tag WHERE tag = :tag AND enabled = TRUE"),
-  @NamedQuery(name = "Topic.findByCompany", query = "SELECT topic FROM Topic topic WHERE topic.creator.company = :company AND enabled = TRUE") })
+  @NamedQuery(name = "Topic.findByCompany", query = "SELECT topic FROM Topic topic WHERE topic.creator.company = :company AND enabled = TRUE"),
+  @NamedQuery(name = "Topic.countByCompany", query = "SELECT COUNT(topic) FROM Topic topic WHERE topic.creator.company = :company AND enabled = TRUE") })
 public class Topic {
 
   @Id

--- a/studenthub-portal/src/main/java/cz/studenthub/db/CompanyPlanDAO.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/db/CompanyPlanDAO.java
@@ -20,45 +20,40 @@ import java.util.List;
 
 import org.hibernate.SessionFactory;
 
-import cz.studenthub.core.Activation;
-import cz.studenthub.core.User;
+import cz.studenthub.core.CompanyPlan;
 import io.dropwizard.hibernate.AbstractDAO;
 
 /**
- * Data(base) Access Object for Activation objects.
+ * Data(base) Access Object for CompanyPlan objects.
  * 
  * @author phala
- * @since 1.0
+ * @since 1.1
  */
-public class ActivationDAO extends AbstractDAO<Activation> {
+public class CompanyPlanDAO extends AbstractDAO<CompanyPlan> {
 
-  public ActivationDAO(SessionFactory sessionFactory) {
+  public CompanyPlanDAO(SessionFactory sessionFactory) {
     super(sessionFactory);
   }
 
-  public Activation update(Activation activation) {
+  public CompanyPlan update(CompanyPlan company) {
     currentSession().clear();
-    return persist(activation);
+    return persist(company);
   }
   
-  public Activation create(Activation activation) {
-    return persist(activation);
+  public CompanyPlan create(CompanyPlan company) {
+    return persist(company);
   }
-
-  public Activation findById(long id) {
-    return get(id);
+  
+  public CompanyPlan findByName(String name) {
+    return get(name);
   }
-
-  public Activation findByUser(User user) {
-    return uniqueResult(namedQuery("Activation.findByUser").setParameter("user", user));
+  
+  public List<CompanyPlan> findAll() {
+    return list(namedQuery("CompanyPlan.findAll"));
   }
-
-  public List<Activation> findAll() {
-    return list(namedQuery("Activation.findAll"));
-  }
-
-  public void delete(Activation activation) {
-    currentSession().delete(activation);
+  
+  public void delete(CompanyPlan company) {
+    currentSession().delete(company);
   }
 
 }

--- a/studenthub-portal/src/main/java/cz/studenthub/db/TaskDAO.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/db/TaskDAO.java
@@ -8,6 +8,12 @@ import cz.studenthub.core.Task;
 import cz.studenthub.core.TopicApplication;
 import io.dropwizard.hibernate.AbstractDAO;
 
+/**
+ * Data(base) Access Object for Task objects.
+ * 
+ * @author phala
+ * @since 1.0
+ */
 public class TaskDAO extends AbstractDAO<Task> {
 
   public TaskDAO(SessionFactory sessionFactory) {

--- a/studenthub-portal/src/main/java/cz/studenthub/db/TopicDAO.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/db/TopicDAO.java
@@ -68,6 +68,10 @@ public class TopicDAO extends AbstractDAO<Topic> {
     return list(namedQuery("Topic.findByCompany").setParameter("company", company));
   }
 
+  public int countByCompany(Company company) {
+    return ((Number) namedQuery("Topic.countByCompany").setParameter("company", company).getSingleResult()).intValue();
+  }
+
   public List<Topic> findAll() {
     return list(namedQuery("Topic.findAll"));
   }

--- a/studenthub-portal/src/main/java/cz/studenthub/resources/CompanyPlanResource.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/resources/CompanyPlanResource.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ *     Copyright (C) 2017  Stefan Bunciak
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *******************************************************************************/
+package cz.studenthub.resources;
+
+import java.util.List;
+
+import javax.annotation.security.RolesAllowed;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Timed;
+
+import cz.studenthub.core.CompanyPlan;
+import cz.studenthub.db.CompanyPlanDAO;
+import cz.studenthub.util.PagingUtil;
+import io.dropwizard.hibernate.UnitOfWork;
+import io.dropwizard.jersey.params.IntParam;
+
+@Path("/plans")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class CompanyPlanResource {
+
+  private final CompanyPlanDAO cpDao;
+
+  public CompanyPlanResource(CompanyPlanDAO cpDao) {
+    this.cpDao = cpDao;
+  }
+
+  @GET
+  @Timed
+  @UnitOfWork
+  public List<CompanyPlan> fetch(@Min(0) @DefaultValue("0") @QueryParam("start") IntParam startParam,
+          @Min(0) @DefaultValue("0") @QueryParam("size") IntParam sizeParam) {
+    return PagingUtil.paging(cpDao.findAll(), startParam.get(), sizeParam.get());
+  }
+
+  @GET
+  @Path("/{name}")
+  @UnitOfWork
+  public CompanyPlan findByName(@PathParam("name") String name) {
+    return cpDao.findByName(name);
+  }
+
+  @POST
+  @ExceptionMetered
+  @UnitOfWork
+  @RolesAllowed("ADMIN")
+  public Response create(@NotNull @Valid CompanyPlan companyPlan) {
+    CompanyPlan returned = cpDao.create(companyPlan);
+
+    return Response.created(UriBuilder.fromResource(CompanyPlanResource.class).path("/{name}").build(returned.getName()))
+        .entity(companyPlan).build();
+  }
+
+  @PUT
+  @ExceptionMetered
+  @Path("/{name}")
+  @UnitOfWork
+  @RolesAllowed("ADMIN")
+  public Response update(@PathParam("name") String name, @NotNull @Valid CompanyPlan companyPlan) {
+    if (cpDao.findByName(name) == null) 
+      throw new WebApplicationException(Status.NOT_FOUND);
+
+    companyPlan.setName(name);
+    cpDao.update(companyPlan);
+    return Response.ok(companyPlan).build();
+  }
+
+  @DELETE
+  @ExceptionMetered
+  @Path("/{name}")
+  @UnitOfWork
+  @RolesAllowed("ADMIN")
+  public Response delete(@PathParam("name") String name) {
+    CompanyPlan companyPlan = cpDao.findByName(name);
+    if (companyPlan == null) 
+      throw new WebApplicationException(Status.NOT_FOUND);
+
+    cpDao.delete(companyPlan);
+    return Response.noContent().build();
+  }
+
+}

--- a/studenthub-portal/src/main/resources/db/InitialData.md
+++ b/studenthub-portal/src/main/resources/db/InitialData.md
@@ -14,11 +14,17 @@ Initial Database migration file contains these entries:
 | --- | ---------------------------------- |
 | 1   | Faculty of Informatics             |
 
+## Company Plans
+
+| name   | maxTopics | description      |
+| ------ | --------- | ---------------- |
+| TIER_1 | 3         | For basic use    |
+
 ## Companies
 
 | id  | name                               | logoUrl                | city       | country | url            | size      | plan    |
 | --- | ---------------------------------- | ---------------------- | ---------- | ------  | -------------- | --------- | ------- |
-| 1   | Company One                        | c1.com/logo.png        | Brno       | CZ      | www.c1.com     | CORPORATE | TIER_3  | 
+| 1   | Company One                        | c1.com/logo.png        | Brno       | CZ      | www.c1.com     | CORPORATE | TIER_1  | 
 
 ## Users
 

--- a/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.1.xml
+++ b/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.1.xml
@@ -1,8 +1,27 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-	<changeSet author="phala" id="secondaryTitle">
+  	<changeSet author="phala" id="secondaryTitle">
 	    <addColumn catalogName="studenthub" schemaName="public" tableName="topics">
-	        <column name="secondarytitle" type="VARCHAR(255)"/>
-	    </addColumn>
-	</changeSet>
+            <column name="secondarytitle" type="VARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="phala (generated)" id="companyPlans">
+        <createTable catalogName="studenthub" schemaName="public" tableName="plans">
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="maxtopics" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="Text"/>
+        </createTable>
+        <addPrimaryKey catalogName="studenthub" columnNames="name" constraintName="plans_pkey" schemaName="public" tableName="plans"/>
+        <dropColumn columnName="plan" catalogName="studenthub" schemaName="public" tableName="companies"/>
+        <addColumn catalogName="studenthub" schemaName="public" tableName="companies">
+            <column name="plan_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addForeignKeyConstraint baseColumnNames="plan_name" baseTableCatalogName="studenthub" baseTableName="companies" baseTableSchemaName="public" constraintName="fkh0lcq5n9spp872lv9lwrc0016" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="name" referencedTableCatalogName="studenthub" referencedTableName="plans" referencedTableSchemaName="public"/>
+    </changeSet>	
 </databaseChangeLog>

--- a/studenthub-portal/src/main/resources/migrations.xml
+++ b/studenthub-portal/src/main/resources/migrations.xml
@@ -6,5 +6,5 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
   <include file="db/changelog/db.changelog-1.0.xml"/> 
-  <include file="db/changelog/db.changelog-1.1.xml"/>  
+  <include file="db/changelog/db.changelog-1.1.xml"/>
 </databaseChangeLog> 

--- a/studenthub-portal/src/test/java/cz/studenthub/DAOTestSuite.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/DAOTestSuite.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import cz.studenthub.core.Activation;
 import cz.studenthub.core.Company;
+import cz.studenthub.core.CompanyPlan;
 import cz.studenthub.core.Faculty;
 import cz.studenthub.core.Task;
 import cz.studenthub.core.Topic;
@@ -25,6 +26,7 @@ import cz.studenthub.core.University;
 import cz.studenthub.core.User;
 import cz.studenthub.db.ActivationDAOTest;
 import cz.studenthub.db.CompanyDAOTest;
+import cz.studenthub.db.CompanyPlanDAOTest;
 import cz.studenthub.db.FacultyDAOTest;
 import cz.studenthub.db.TaskDAOTest;
 import cz.studenthub.db.TopicApplicationDAOTest;
@@ -43,7 +45,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 
 @RunWith(Suite.class)
 @SuiteClasses({ CompanyDAOTest.class, FacultyDAOTest.class, TaskDAOTest.class, TopicApplicationDAOTest.class,
-   TopicDAOTest.class, UniversityDAOTest.class, UserDAOTest.class, ActivationDAOTest.class})
+   TopicDAOTest.class, UniversityDAOTest.class, UserDAOTest.class, ActivationDAOTest.class, CompanyPlanDAOTest.class})
 public class DAOTestSuite {
 
   public static DAOTestRule database;
@@ -67,7 +69,8 @@ public class DAOTestSuite {
         .addEntityClass(University.class)
         .addEntityClass(TopicApplication.class)
         .addEntityClass(Task.class)
-        .addEntityClass(Activation.class).build();
+        .addEntityClass(Activation.class)
+        .addEntityClass(CompanyPlan.class).build();
   }
 
   public static void migrateDatabase() {

--- a/studenthub-portal/src/test/java/cz/studenthub/db/ActivationDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/ActivationDAOTest.java
@@ -14,7 +14,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class ActivationDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static ActivationDAO actDAO;
   private static UserDAO userDAO;
 

--- a/studenthub-portal/src/test/java/cz/studenthub/db/CompanyDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/CompanyDAOTest.java
@@ -18,17 +18,20 @@ public class CompanyDAOTest {
 
   public static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static CompanyDAO companyDAO;
+  private static CompanyPlanDAO cpDAO;
 
   @BeforeClass
   public static void setUp() {
     companyDAO = new CompanyDAO(DATABASE.getSessionFactory());
+    cpDAO = new CompanyPlanDAO(DATABASE.getSessionFactory());
   }
 
   @Test
   public void createCompany() {
-    Company company = new Company("New", "www.nothing.eu", "Liberec", Country.CZ, "www.nothing.eu/logo.png",
-        CompanySize.SMALL, CompanyPlan.TIER_2);
     DAOTestSuite.inRollbackTransaction(() -> {
+      CompanyPlan cPlan = cpDAO.findByName("TIER_2");
+      Company company = new Company("New", "www.nothing.eu", "Liberec", Country.CZ, "www.nothing.eu/logo.png",
+          CompanySize.SMALL, cPlan);
       Company created = companyDAO.create(company);
       List<Company> companies = companyDAO.findAll();
       assertNotNull(created.getId());

--- a/studenthub-portal/src/test/java/cz/studenthub/db/CompanyDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/CompanyDAOTest.java
@@ -16,7 +16,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class CompanyDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static CompanyDAO companyDAO;
   private static CompanyPlanDAO cpDAO;
 

--- a/studenthub-portal/src/test/java/cz/studenthub/db/CompanyPlanDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/CompanyPlanDAOTest.java
@@ -1,0 +1,66 @@
+package cz.studenthub.db;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import cz.studenthub.DAOTestSuite;
+import cz.studenthub.core.CompanyPlan;
+import io.dropwizard.testing.junit.DAOTestRule;
+
+public class CompanyPlanDAOTest {
+
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static CompanyPlanDAO cpDAO;
+
+  @BeforeClass
+  public static void setUp() {
+    cpDAO = new CompanyPlanDAO(DATABASE.getSessionFactory());
+  }
+
+  @Test
+  public void createCompanyPlan() {
+    DAOTestSuite.inRollbackTransaction(() -> {
+      CompanyPlan cPlan = new CompanyPlan("TIER_5", 50);
+      CompanyPlan created = cpDAO.create(cPlan);
+      List<CompanyPlan> cPlans = cpDAO.findAll();
+
+      assertEquals(cPlan, created);
+      assertEquals(5, cPlans.size());
+    });
+  }
+
+  @Test
+  public void fetchCompanyPlan() {
+    CompanyPlan cPlan = DATABASE.inTransaction(() -> {
+      return cpDAO.findByName("TIER_2");
+    });
+
+    assertNotNull(cPlan);
+    assertEquals(5, cPlan.getMaxTopics());
+  }
+
+  @Test
+  public void listAllCompanyPlans() {
+    List<CompanyPlan> companies = DATABASE.inTransaction(() -> {
+      return cpDAO.findAll();
+    });
+    assertNotNull(companies);
+    assertEquals(4, companies.size());
+  }
+
+  @Test
+  public void removeCompanyPlan() {
+    DAOTestSuite.inRollbackTransaction(() -> {
+      CompanyPlan cPlan = cpDAO.findByName("TIER_4");
+      cpDAO.delete(cPlan);
+      List<CompanyPlan> cPlans = cpDAO.findAll();
+      assertNotNull(cPlan);
+      assertEquals(3, cPlans.size());
+      assertFalse(cPlans.contains(cPlan));
+    });
+  }
+}

--- a/studenthub-portal/src/test/java/cz/studenthub/db/FacultyDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/FacultyDAOTest.java
@@ -14,7 +14,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class FacultyDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static FacultyDAO facDAO;
   private static UniversityDAO uniDAO;
 

--- a/studenthub-portal/src/test/java/cz/studenthub/db/TaskDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/TaskDAOTest.java
@@ -17,7 +17,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class TaskDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static TaskDAO taskDao;
   private static TopicApplicationDAO appDao;
 

--- a/studenthub-portal/src/test/java/cz/studenthub/db/TopicApplicationDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/TopicApplicationDAOTest.java
@@ -18,7 +18,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class TopicApplicationDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static FacultyDAO facDAO;
   private static UserDAO userDAO;
   private static TopicDAO topicDAO;

--- a/studenthub-portal/src/test/java/cz/studenthub/db/TopicDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/TopicDAOTest.java
@@ -16,7 +16,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class TopicDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static CompanyDAO companyDAO;
   private static UserDAO userDAO;
   private static TopicDAO topicDAO;

--- a/studenthub-portal/src/test/java/cz/studenthub/db/UniversityDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/UniversityDAOTest.java
@@ -14,7 +14,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class UniversityDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static UniversityDAO uniDAO;
 
   @BeforeClass

--- a/studenthub-portal/src/test/java/cz/studenthub/db/UserDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/UserDAOTest.java
@@ -16,7 +16,7 @@ import io.dropwizard.testing.junit.DAOTestRule;
 
 public class UserDAOTest {
 
-  public static final DAOTestRule DATABASE = DAOTestSuite.database;
+  private static final DAOTestRule DATABASE = DAOTestSuite.database;
   private static FacultyDAO facDAO;
   private static CompanyDAO companyDAO;
   private static UserDAO userDAO;

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyPlanResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyPlanResourceTest.java
@@ -1,0 +1,94 @@
+package cz.studenthub.integration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import java.util.List;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import cz.studenthub.StudentHubConfiguration;
+import cz.studenthub.IntegrationTestSuite;
+import cz.studenthub.core.CompanyPlan;
+import io.dropwizard.testing.DropwizardTestSupport;
+import net.minidev.json.JSONObject;
+
+public class CompanyPlanResourceTest {
+  private DropwizardTestSupport<StudentHubConfiguration> dropwizard;
+  private Client client;
+
+  @BeforeClass
+  public void setup() {
+      dropwizard = IntegrationTestSuite.DROPWIZARD;
+      client = IntegrationTestSuite.BUILDER.build("CompanyPlanTest");
+  }
+
+  private List<CompanyPlan> fetchCompanyPlans() {
+    return IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/plans/", dropwizard.getLocalPort()))
+      .request(), client).get(new GenericType<List<CompanyPlan>>(){});
+  }
+
+  @Test(dependsOnGroups = "login")
+  public void listCompanyPlans() {
+    List<CompanyPlan> list = fetchCompanyPlans();
+
+    assertNotNull(list);
+    assertEquals(list.size(), 4);
+  }
+
+  @Test(dependsOnGroups = "login")
+  public void fetchCompanyPlan() {
+    CompanyPlan company = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/plans/TIER_1", dropwizard.getLocalPort()))
+        .request(MediaType.APPLICATION_JSON), client).get(CompanyPlan.class);
+
+    assertNotNull(company);
+    assertEquals(company.getMaxTopics(), 3);
+  }
+
+  @Test(dependsOnMethods = "listCompanyPlans")
+  public void createCompanyPlan() {
+    JSONObject plan = new JSONObject();
+    plan.put("name", "TIER_5");
+    plan.put("maxTopics", 20);
+    
+    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/plans", dropwizard.getLocalPort()))
+      .request(MediaType.APPLICATION_JSON), client).post(Entity.json(plan.toJSONString()));
+
+    assertNotNull(response);
+    assertEquals(response.getStatus(), 201);
+    assertEquals(fetchCompanyPlans().size(), 5);
+  }
+
+  @Test(dependsOnMethods = "createCompanyPlan")
+  public void updateCompanyPlan() {
+    JSONObject plan = new JSONObject();
+    plan.put("name", "TIER_5");
+    plan.put("maxTopics", 10);
+
+    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/plans/TIER_5", dropwizard.getLocalPort()))
+      .request(MediaType.APPLICATION_JSON), client).put(Entity.json(plan.toJSONString()));
+
+    assertNotNull(response);
+    assertEquals(response.getStatus(), 200);
+    assertEquals(response.readEntity(CompanyPlan.class).getMaxTopics(), 10);
+  }
+
+  @Test(dependsOnMethods = "updateCompanyPlan")
+  public void deleteCompanyPlan() {
+    Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/plans/TIER_5", dropwizard.getLocalPort())).request(), client)
+      .delete();
+    List<CompanyPlan> list = fetchCompanyPlans();
+
+    assertNotNull(response);
+    assertEquals(response.getStatus(), 204);
+    assertEquals(list.size(), 4);
+  }
+
+}

--- a/studenthub-portal/src/test/resources/config-test.yml
+++ b/studenthub-portal/src/test/resources/config-test.yml
@@ -11,6 +11,9 @@ server:
   applicationConnectors:
     - type: http
       port: 8085
+  adminConnectors:
+    - type: http
+      port: 8082      
 
 # database - development conf. (not for prod. usage)
 database:

--- a/studenthub-portal/src/test/resources/db/DB.md
+++ b/studenthub-portal/src/test/resources/db/DB.md
@@ -45,6 +45,17 @@ Test Database contains these entries:
 | 12   | Faculty of Chemical and Food Technology                                |
 | 13   | Faculty of Civil Engineering                                           |
 
+## Company Plans
+
+Infinite is represented as 0 in DB
+
+| name   | maxTopics | description      |
+| ------ | --------- | ---------------- |
+| TIER_1 | 3         | For basic use    |
+| TIER_2 | 5         | Meh              |
+| TIER_3 | 10        | Good enough      |
+| TIER_4 | INFINITE  | Godlike          |
+
 ## Companies
 
 | id  | name                               | logoUrl                | city       | country | url            | size      | plan    |

--- a/studenthub-portal/src/test/resources/db/test-data.xml
+++ b/studenthub-portal/src/test/resources/db/test-data.xml
@@ -1,5 +1,27 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet author="phala (generated)" id="1489653927422-29" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="PLANS">
+            <column name="NAME" value="TIER_1"/>
+            <column name="MAXTOPICS" valueNumeric="3"/>
+            <column name="DESCRIPTION" value="For basic use"/>
+        </insert>
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="PLANS">
+            <column name="NAME" value="TIER_2"/>
+            <column name="MAXTOPICS" valueNumeric="5"/>
+            <column name="DESCRIPTION" value="Meh"/>
+        </insert>
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="PLANS">
+            <column name="NAME" value="TIER_3"/>
+            <column name="MAXTOPICS" valueNumeric="10"/>
+            <column name="DESCRIPTION" value="Good enough"/>
+        </insert>
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="PLANS">
+            <column name="NAME" value="TIER_4"/>
+            <column name="MAXTOPICS" valueNumeric="0"/>
+            <column name="DESCRIPTION" value="Godlike"/>
+        </insert>        
+    </changeSet>
     <changeSet author="phala (generated)" id="1489653927422-18" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="2"/>
@@ -7,7 +29,7 @@
             <column name="COUNTRY" value="SK"/>
             <column name="LOGOURL" value="c2.com/logo.jpg"/>
             <column name="NAME" value="Company Two"/>
-            <column name="PLAN" value="TIER_2"/>
+            <column name="PLAN_NAME" value="TIER_2"/>
             <column name="SIZE" value="MEDIUM"/>
             <column name="URL" value="www.c2.com"/>
         </insert>
@@ -17,7 +39,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="c1.com/logo.png"/>
             <column name="NAME" value="Company One"/>
-            <column name="PLAN" value="TIER_3"/>
+            <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="CORPORATE"/>
             <column name="URL" value="www.c1.com"/>
         </insert>
@@ -27,7 +49,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="c3.com/img.jpg"/>
             <column name="NAME" value="Company Three"/>
-            <column name="PLAN" value="TIER_3"/>
+            <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="SMALL"/>
             <column name="URL" value="www.c3.com"/>
         </insert>
@@ -37,7 +59,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="c4.com/picture.jpg"/>
             <column name="NAME" value="Company Four"/>
-            <column name="PLAN" value="TIER_1"/>
+            <column name="PLAN_NAME" value="TIER_1"/>
             <column name="SIZE" value="STARTUP"/>
             <column name="URL" value="www.c4.com"/>
         </insert>
@@ -47,7 +69,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="c5.com/us.jpg"/>
             <column name="NAME" value="Company Five"/>
-            <column name="PLAN" value="TIER_3"/>
+            <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="MEDIUM"/>
             <column name="URL" value="www.c5.com"/>
         </insert>
@@ -57,7 +79,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="c6.com/us.gif"/>
             <column name="NAME" value="Company Six"/>
-            <column name="PLAN" value="TIER_2"/>
+            <column name="PLAN_NAME" value="TIER_2"/>
             <column name="SIZE" value="CORPORATE"/>
             <column name="URL" value="www.c6.com"/>
         </insert>
@@ -67,7 +89,7 @@
             <column name="COUNTRY" value="SK"/>
             <column name="LOGOURL" value="c7.com/img.png"/>
             <column name="NAME" value="Company Seven"/>
-            <column name="PLAN" value="TIER_3"/>
+            <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="MEDIUM"/>
             <column name="URL" value="www.c7.com"/>
         </insert>
@@ -77,7 +99,7 @@
             <column name="COUNTRY" value="SK"/>
             <column name="LOGOURL" value="c8.com/logo.jpg"/>
             <column name="NAME" value="Company Eight"/>
-            <column name="PLAN" value="TIER_1"/>
+            <column name="PLAN_NAME" value="TIER_1"/>
             <column name="SIZE" value="STARTUP"/>
             <column name="URL" value="www.c8.com"/>
         </insert>
@@ -690,7 +712,7 @@
             <column name="CREATOR_ID" valueNumeric="10"/>
         </insert>
     </changeSet>
-     <changeSet author="phala (generated)" id="1489653927422-20" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
+    <changeSet author="phala (generated)" id="1489653927422-20" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="TOPIC_DEGREES">
             <column name="TOPIC_ID" valueNumeric="2"/>
             <column name="DEGREES" valueNumeric="0"/>

--- a/studenthub-portal/src/test/resources/testng.xml
+++ b/studenthub-portal/src/test/resources/testng.xml
@@ -5,6 +5,7 @@
 	    <classes>
 	        <class name="cz.studenthub.IntegrationTestSuite"/>
 	        <class name="cz.studenthub.integration.LoginResourceTest"/>
+	        <class name="cz.studenthub.integration.CompanyPlanResourceTest"/>
 	        <class name="cz.studenthub.integration.CompanyResourceTest"/>
 	        <class name="cz.studenthub.integration.UniversityResourceTest"/>
 	        <class name="cz.studenthub.integration.FacultyResourceTest"/>


### PR DESCRIPTION
* `CompanyPlan` is now stored in database instead of being enum.
  * Added `description` and `maxTopics` into `CompanyPlan`.
  * Updated all migration files and database configurations to reflect this change.
  * Added `CompanyPlanResource` resource class for basic CRUD operations.
* Made `plan` in `Company` not visible.
* Companies can now have only limited number of enabled topics.
* Added namedQuery for counting `Company` topics.
* Fixed wrong modifiers in DAO tests.
* Fixed missing or wrong JavaDoc comments in DAO classes.
* Integration tests now run on different ports than production config.