### PR TITLE
#102 - Add additional step when resetting password

### DIFF
--- a/studenthub-portal/src/main/java/cz/studenthub/core/Activation.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/Activation.java
@@ -3,6 +3,8 @@ package cz.studenthub.core;
 import java.util.Objects;
 
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -21,6 +23,7 @@ import cz.studenthub.auth.StudentHubPasswordEncoder;
 @Entity
 @Table(name = "Activations")
 @NamedQueries({ @NamedQuery(name = "Activation.findByUser", query = "SELECT activation FROM Activation activation WHERE user = :user"),
+  @NamedQuery(name = "Activation.findByUserAndType", query = "SELECT activation FROM Activation activation WHERE user = :user AND type = :type"),
   @NamedQuery(name = "Activation.findAll", query = "SELECT activation FROM Activation activation")})
 public class Activation {
 
@@ -36,16 +39,21 @@ public class Activation {
     @NotEmpty
     private String activationCode;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private ActivationType type;
+    
     public Activation(){
     }
 
-    public Activation(User user, String activationCode) {
+    public Activation(User user, String activationCode, ActivationType type) {
       this.user = user;
       this.activationCode = activationCode;
+      this.type = type;
     }
 
-    public Activation(User user) {
-      this(user, StudentHubPasswordEncoder.genSecret());
+    public Activation(User user, ActivationType type) {
+      this(user, StudentHubPasswordEncoder.genSecret(), type);
     }
 
     public Long getId() {
@@ -70,6 +78,14 @@ public class Activation {
 
     public void setActivationCode(String activationCode) {
       this.activationCode = activationCode;
+    }
+
+    public ActivationType getType() {
+      return type;
+    }
+
+    public void setType(ActivationType type) {
+      this.type = type;
     }
 
     @Override

--- a/studenthub-portal/src/main/java/cz/studenthub/core/ActivationType.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/ActivationType.java
@@ -1,0 +1,5 @@
+package cz.studenthub.core;
+
+public enum ActivationType {
+  REGISTER, PASSWORD_RESET
+}

--- a/studenthub-portal/src/main/java/cz/studenthub/db/ActivationDAO.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/db/ActivationDAO.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.hibernate.SessionFactory;
 
 import cz.studenthub.core.Activation;
+import cz.studenthub.core.ActivationType;
 import cz.studenthub.core.User;
 import io.dropwizard.hibernate.AbstractDAO;
 
@@ -51,6 +52,10 @@ public class ActivationDAO extends AbstractDAO<Activation> {
 
   public Activation findByUser(User user) {
     return uniqueResult(namedQuery("Activation.findByUser").setParameter("user", user));
+  }
+
+  public Activation findByUserAndType(User user, ActivationType type) {
+    return uniqueResult(namedQuery("Activation.findByUserAndType").setParameter("user", user).setParameter("type", type));
   }
 
   public List<Activation> findAll() {

--- a/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.1.xml
+++ b/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.1.xml
@@ -24,6 +24,11 @@
         </addColumn>
         <addForeignKeyConstraint baseColumnNames="plan_name" baseTableCatalogName="studenthub" baseTableName="companies" baseTableSchemaName="public" constraintName="fkh0lcq5n9spp872lv9lwrc0016" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="name" referencedTableCatalogName="studenthub" referencedTableName="plans" referencedTableSchemaName="public"/>
     </changeSet>
+    <changeSet author="phala" id="activationType">
+        <addColumn catalogName="studenthub" schemaName="public" tableName="activations">
+            <column name="type" type="VARCHAR(255)" defaultValue="REGISTER"/>
+        </addColumn>
+    </changeSet>
 	<changeSet author="phala (generated)" id="projects">
         <createTable catalogName="studenthub" schemaName="public" tableName="projects">
             <column autoIncrement="true" name="id" type="BIGSERIAL">

--- a/studenthub-portal/src/main/resources/templates/resetPassword.html
+++ b/studenthub-portal/src/main/resources/templates/resetPassword.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
+    <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css' />
+    <title>Password setup</title>
+    <style type="text/css">
+      body {
+        font-family: 'Roboto', sans-serif;
+      }
+      .wrapper {
+        box-shadow: 1px 1px 1px #888888;
+      }
+    </style>
+  </head>
+  <body style="margin:10px 0px 0px 0px; padding:0; background-color:#FFFFFF;">
+    <center>
+      <table width="640" cellpadding="0" cellspacing="0" border="0" class="wrapper" bgcolor="#FFFFFF">
+        <tr>
+          <td height="10" style="font-size:10px; line-height:10px;">&nbsp;
+          </td>
+        </tr>
+        <tr>
+          <td align="center" valign="top">
+
+            <table width="600" cellpadding="0" cellspacing="0" border="0" class="container">
+              <tr>
+                <td valign="top">
+                  <h1>Pasword setup</h1>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" class="email-body">
+                  <p>Hello __name__,</p>
+                  <p>Someone requested password reset for your account.</p>
+                  <p>Click here <a href="https://portal.studenthub.cz/confirmReset?secret=__secret__&id=__id__">here</a> to reset your password.</p>
+              </tr>
+              <tr>
+                <td class="email-footer" align="center" valign="top">
+                  <hr />
+                  <p>Student Hub &copy; 2017</p>
+                    <p>
+                      <a href="https://facebook.com/StudentHub" target="_blank">
+                        <i class="fa fa-facebook-official" aria-hidden="true"></i>
+                      </a>
+                      <a href="https://twitter.com/StudentHubCZ" target="_blank">
+                        <i class="fa fa-twitter-square" aria-hidden="true"></i>
+                      </a>
+                      <a href="https://github.com/StudentHubCZ" target="_blank">
+                        <i class="fa fa-github-square" aria-hidden="true"></i>
+                      </a>
+                    </p>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td height="10" style="font-size:10px; line-height:10px;">&nbsp;
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
+</html>

--- a/studenthub-portal/src/test/java/cz/studenthub/db/ActivationDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/ActivationDAOTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import cz.studenthub.DAOTestSuite;
 import cz.studenthub.core.Activation;
+import cz.studenthub.core.ActivationType;
 import cz.studenthub.core.User;
 import io.dropwizard.testing.junit.DAOTestRule;
 
@@ -28,14 +29,14 @@ public class ActivationDAOTest {
   public void createActivation() {
     DAOTestSuite.inRollbackTransaction(() -> {
       User user = userDAO.findById((long) 1);
-      Activation act = new Activation(user);
+      Activation act = new Activation(user, ActivationType.REGISTER);
 
       Activation created = actDAO.create(act);
 
       List<Activation> activations = actDAO.findAll();
       assertNotNull(created.getId());
       assertEquals(act, created);
-      assertEquals(3, activations.size());
+      assertEquals(4, activations.size());
     });
   }
 
@@ -51,12 +52,36 @@ public class ActivationDAOTest {
   }
 
   @Test
+  public void fetchActivationByUser() {
+    Activation act = DATABASE.inTransaction(() -> {
+      User user = userDAO.findById((long) 9);
+      return actDAO.findByUser(user);
+    });
+
+    assertNotNull(act);
+    assertEquals("leader2", act.getActivationCode());
+    assertEquals(ActivationType.PASSWORD_RESET, act.getType());
+  }
+
+  @Test
+  public void fetchActivationByUserAndType() {
+    Activation act = DATABASE.inTransaction(() -> {
+      User user = userDAO.findById((long) 15);
+      return actDAO.findByUserAndType(user, ActivationType.REGISTER);
+    });
+
+    assertNotNull(act);
+    assertEquals("student4", act.getActivationCode());
+    assertEquals(ActivationType.REGISTER, act.getType());
+  }
+
+  @Test
   public void listAllActivations() {
     List<Activation> activations = DATABASE.inTransaction(() -> {
       return actDAO.findAll();
     });
     assertNotNull(activations);
-    assertEquals(2, activations.size());
+    assertEquals(3, activations.size());
   }
 
   @Test
@@ -67,7 +92,7 @@ public class ActivationDAOTest {
       actDAO.delete(activation);
       List<Activation> activations = actDAO.findAll();
       assertNotNull(activation);
-      assertEquals(1, activations.size());
+      assertEquals(2, activations.size());
       assertFalse(activations.contains(activation));
     });
   }

--- a/studenthub-portal/src/test/resources/db/test-data.xml
+++ b/studenthub-portal/src/test/resources/db/test-data.xml
@@ -1019,12 +1019,20 @@
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="ACTIVATIONS">
             <column name="ID" valueNumeric="1"/>
             <column name="ACTIVATIONCODE" value="rep3"/>
+            <column name="TYPE" value="REGISTER"/>
             <column name="USER_ID" valueNumeric="18"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="ACTIVATIONS">
             <column name="ID" valueNumeric="2"/>
             <column name="ACTIVATIONCODE" value="student4"/>
+            <column name="TYPE" value="REGISTER"/>
             <column name="USER_ID" valueNumeric="15"/>
+        </insert>
+        <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="ACTIVATIONS">
+            <column name="ID" valueNumeric="3"/>
+            <column name="ACTIVATIONCODE" value="leader2"/>
+            <column name="TYPE" value="PASSWORD_RESET"/>
+            <column name="USER_ID" valueNumeric="9"/>
         </insert>
     </changeSet>
     <changeSet author="phala (generated)" id="1496737117875-30">

--- a/studenthub-ui/src/App.js
+++ b/studenthub-ui/src/App.js
@@ -7,6 +7,7 @@ import TopicSearch from './views/TopicSearch.js';
 import SignIn from './views/SignIn.js';
 import SignUp from './views/SignUp.js';
 import Activation from './views/Activation.js';
+import ResetConfirmation from './views/ResetConfirmation.js';
 import ForgotPassword from './views/ForgotPassword.js';
 import UpdatePassword from './views/UpdatePassword.js';
 import Users from './views/Users.js';
@@ -113,6 +114,7 @@ class App extends Component {
               <Route exact path="/signup" component={SignUp}/>
               <Route exact path="/forgotPwd" component={ForgotPassword}/>
               <Route exact path="/activation/:id/:secret" component={Activation}/>
+              <Route exact path="/confirmReset/:id/:secret" component={ResetConfirmation}/>
               <Route exact path="/topics/:id" component={Topic}/>
               <PrivateRoute exact path="/users" component={Users}/>
               <PrivateRoute exact path="/unis" component={Universities}/>

--- a/studenthub-ui/src/App.js
+++ b/studenthub-ui/src/App.js
@@ -8,6 +8,7 @@ import SignIn from './views/SignIn.js';
 import SignUp from './views/SignUp.js';
 import Activation from './views/Activation.js';
 import ForgotPassword from './views/ForgotPassword.js';
+import UpdatePassword from './views/UpdatePassword.js';
 import Users from './views/Users.js';
 import Universities from './views/Universities.js';
 import Companies from './views/Companies.js';
@@ -110,7 +111,7 @@ class App extends Component {
               <Route exact path="/" component={TopicSearch}/>
               <Route exact path="/signin" component={SignIn}/>
               <Route exact path="/signup" component={SignUp}/>
-              <Route exact path="/forgot" component={ForgotPassword}/>
+              <Route exact path="/forgotPwd" component={ForgotPassword}/>
               <Route exact path="/activation/:id/:secret" component={Activation}/>
               <Route exact path="/topics/:id" component={Topic}/>
               <PrivateRoute exact path="/users" component={Users}/>
@@ -120,6 +121,7 @@ class App extends Component {
               <PrivateRoute exact path="/my-apps" component={MyApplications}/>
               <PrivateRoute exact path="/my-topics" component={MyTopics}/>
               <PrivateRoute exact path="/profile" component={Profile}/>
+              <PrivateRoute exact path="/updatePwd" component={UpdatePassword}/>
               <PrivateRoute path="/applications/:id" component={Application}/>
               <Route exact path="/company-reg" component={CompanyReg}/>
               <Route component={NoMatch}/>

--- a/studenthub-ui/src/Auth.js
+++ b/studenthub-ui/src/Auth.js
@@ -15,7 +15,7 @@ const Auth = {
   /**
    * Obtains JWT token from backend which subsequently stores it in Browser cookies
    */
-  authenticate(username, password, cb) {
+  authenticate(username, password, cb, failCb) {
 
     var settings = {
       "url": "/api/auth/login",
@@ -32,13 +32,13 @@ const Auth = {
       }
     }
 
-    // console.log(settings);
-    $.ajax(settings).done(function (data, textStatus, jqXHR) {
-      console.log(textStatus);
-      // TODO: if cookie was not set but Authorization header was returned
-    });
-
-    setTimeout(cb, 500)
+    $.ajax(settings)
+      .done(function() {
+        setTimeout(cb, 500);
+      })
+      .fail(function() {
+        failCb();
+      });
   },
 
   /**

--- a/studenthub-ui/src/Translations.js
+++ b/studenthub-ui/src/Translations.js
@@ -384,6 +384,27 @@ const myLocalize = new Localize({
     },
     'External link': {
       'cs': 'Externí odkaz'
+    },
+    'Change password': {
+      'cs': 'Změňit heslo '
+    },
+    'Old password': {
+      'cs': 'Staré heslo'
+    },
+    'New password': {
+      'cs': 'Nové heslo'
+    },
+    'Retrieve': {
+      'cs': 'Obnov'
+    },
+    'Change': {
+      'cs': 'Změň'
+    },
+    'Password update': {
+      'cs': 'Změna hesla'
+    },
+    'Password retrieval': {
+      'cs': 'Obnovení hesla'
     }
 });
 

--- a/studenthub-ui/src/Translations.js
+++ b/studenthub-ui/src/Translations.js
@@ -405,6 +405,12 @@ const myLocalize = new Localize({
     },
     'Password retrieval': {
       'cs': 'Obnovení hesla'
+    },
+    'Close this': {
+      'cs': 'Zavři'
+    },
+    'Password reset confirmation': {
+      'cs': 'Potvrzení zresetování hesla'
     }
 });
 

--- a/studenthub-ui/src/components/LoginForm.js
+++ b/studenthub-ui/src/components/LoginForm.js
@@ -5,18 +5,13 @@ import Auth from '../Auth.js';
 import Input from 'react-toolbox/lib/input/Input.js';
 import Button from 'react-toolbox/lib/button/Button.js';
 
+import SiteSnackbar from './SiteSnackbar.js';
+
 import _t from '../Translations.js';
 
 class LoginForm extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      email: '',
-      password: '',
-      redirectToReferrer: false
-    };
-  }
+  state = { email: '', password: '', redirectToReferrer: false,
+    snackbarActive: false, snackbarLabel: ''}
 
   handleChange = (name, value) => {
     this.setState({...this.state, [name]: value});
@@ -29,7 +24,14 @@ class LoginForm extends React.Component {
   handleSubmit = () => {
     Auth.authenticate(this.state.email, this.state.password, () => {
       this.setState({ redirectToReferrer: true })
+    }, () => {
+      this.setState({ snackbarLabel: "No such user has been found!",
+        snackbarActive: true })
     });
+  }
+
+  handleToggle = () => {
+    this.setState({ snackbarActive: !this.state.snackbarActive });
   }
 
   render() {
@@ -49,7 +51,8 @@ class LoginForm extends React.Component {
         <Input type='password' label={ _t.translate('Password') } icon='lock' value={this.state.password} onChange={this.handleChange.bind(this, 'password')} required onKeyPress={(e) => this.handleKeyPress(e)} />
         <Button raised primary label={ _t.translate('Sign In') } onClick={() => this.handleSubmit()} />
         <p style={{ paddingTop: '30px'}}>{ _t.translate('Sign Up')} <Link to="/signup">{ _t.translate('here') }</Link>.</p>
-        {/* <p><Link to="/forgot">{ _t.translate('Forgot your password') }?</Link></p> */}
+        <p><Link to="/forgotPwd">{ _t.translate('Forgot your password') }?</Link></p>
+        <SiteSnackbar active={this.state.snackbarActive} label={this.state.snackbarLabel} toggleHandler={() => this.handleToggle()} />
       </div>
     )
   }

--- a/studenthub-ui/src/views/ForgotPassword.js
+++ b/studenthub-ui/src/views/ForgotPassword.js
@@ -4,6 +4,7 @@ import Input from 'react-toolbox/lib/input/Input.js';
 import Button from 'react-toolbox/lib/button/Button.js';
 
 import SiteSnackbar from '../components/SiteSnackbar.js';
+import _t from '../Translations.js';
 
 class ForgotPasswordView extends React.Component {
   state = { email: '', snackbarActive: false, snackbarLabel: '', redirect: false };
@@ -13,14 +14,37 @@ class ForgotPasswordView extends React.Component {
   };
 
   handleSubmit = () => {
-    //TODO: Send a verification request to server.
-    this.setState({
-      snackbarActive: true,
-      snackbarLabel: "Not yet supported, please wait!"
-    });
-    setTimeout(function() {
-      this.setState({ redirect: true });
-    }.bind(this), 1000);
+    var data = new URLSearchParams();
+    data.append("email", this.state.email);
+
+    fetch('/api/account/resetPassword', {
+      method: 'post',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: data
+    }).then(function(response) {
+      if (response.ok) {
+        this.setState({
+          snackbarLabel: "Your password has now been reset. A new activation link has been sent to your email.",
+          snackbarActive: true
+        });
+        setTimeout(function(){
+          this.setState({ redirect: true });
+        }.bind(this), 2000);
+      }
+      else if (response.status === 404) {
+        this.setState({
+          snackbarLabel: "No such email adress has been found!",
+          snackbarActive: true
+        });
+      }
+      else {
+        this.setState({
+          snackbarLabel: "An error occured! Your request couldn't be processed. It's possible that you have a problem with your internet connection or that the server is not responding.",
+          snackbarActive: true
+        });
+        throw new Error('There was a problem with network connection. POST request could not be processed!');
+      }
+    }.bind(this));
   };
 
   handleToggle = () => {
@@ -35,10 +59,11 @@ class ForgotPasswordView extends React.Component {
   render () {
     return (
       <section className='text-center col-md-offset-3 col-md-6'>
-        <h1>Password Retrieval</h1>
-        <Input type='email' label='Email address' hint='Email adress of the retrieved account' icon='email' required value={this.state.email} onChange={this.handleChange.bind(this, 'email')} />
+        <h1>{ _t.translate('Password retrieval') }</h1>
+        <Input type='email' label={ _t.translate('Email address') } hint='Email adress of the retrieved account' icon='email' required
+          value={this.state.email} onChange={this.handleChange.bind(this, 'email')} />
         <br />
-        <Button icon='send' label='Retrieve' raised primary onClick={this.handleSubmit}/>
+        <Button icon='send' label={ _t.translate('Retrieve') } raised primary onClick={this.handleSubmit}/>
         {this.generateRedirect()}
         <SiteSnackbar active={this.state.snackbarActive} toggleHandler={() => this.handleToggle()} label={this.state.snackbarLabel} />
       </section>

--- a/studenthub-ui/src/views/ForgotPassword.js
+++ b/studenthub-ui/src/views/ForgotPassword.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Redirect } from 'react-router';
 import Input from 'react-toolbox/lib/input/Input.js';
 import Button from 'react-toolbox/lib/button/Button.js';
 
@@ -7,7 +6,7 @@ import SiteSnackbar from '../components/SiteSnackbar.js';
 import _t from '../Translations.js';
 
 class ForgotPasswordView extends React.Component {
-  state = { email: '', snackbarActive: false, snackbarLabel: '', redirect: false };
+  state = { email: '', snackbarActive: false, snackbarLabel: '' };
 
   handleChange = (name, value) => {
     this.setState({...this.state, [name]: value});
@@ -24,12 +23,9 @@ class ForgotPasswordView extends React.Component {
     }).then(function(response) {
       if (response.ok) {
         this.setState({
-          snackbarLabel: "Your password has now been reset. A new activation link has been sent to your email.",
+          snackbarLabel: "A confirmation email has now been sent. To reset your password follow its instructions.",
           snackbarActive: true
         });
-        setTimeout(function(){
-          this.setState({ redirect: true });
-        }.bind(this), 2000);
       }
       else if (response.status === 404) {
         this.setState({
@@ -51,11 +47,6 @@ class ForgotPasswordView extends React.Component {
     this.setState({ snackbarActive: false });
   };
 
-  generateRedirect = () => {
-    if(this.state.redirect === false) return;
-    else return (<Redirect to="/signin" />);
-  }
-
   render () {
     return (
       <section className='text-center col-md-offset-3 col-md-6'>
@@ -64,7 +55,6 @@ class ForgotPasswordView extends React.Component {
           value={this.state.email} onChange={this.handleChange.bind(this, 'email')} />
         <br />
         <Button icon='send' label={ _t.translate('Retrieve') } raised primary onClick={this.handleSubmit}/>
-        {this.generateRedirect()}
         <SiteSnackbar active={this.state.snackbarActive} toggleHandler={() => this.handleToggle()} label={this.state.snackbarLabel} />
       </section>
     );

--- a/studenthub-ui/src/views/Profile.js
+++ b/studenthub-ui/src/views/Profile.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { withRouter } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import Avatar from 'react-toolbox/lib/avatar/Avatar.js';
 import Input from 'react-toolbox/lib/input/Input.js';
 import Button from 'react-toolbox/lib/button/Button.js';
@@ -24,7 +25,7 @@ const LogoutButton = withRouter(({ history }) => (
 
 class ProfileEditView extends React.Component {
   state = { email: '', avatarUrl: '', name: '', phone: '', roles: [],  tags: '',
-  lastLogin: [], snackbarActive: false, snackbarLabel: '' };
+  lastLogin: [], snackbarActive: false, snackbarLabel: '', redirect: false };
 
   componentDidMount() {
     this.getUser();
@@ -69,9 +70,7 @@ class ProfileEditView extends React.Component {
     fetch('/api/users/' + Auth.getUserInfo().sub, {
       method: 'put',
       credentials: 'same-origin',
-      headers: {
-        "Content-Type" : "application/json"
-      },
+      headers: { "Content-Type" : "application/json" },
       body: JSON.stringify({
         name: this.state.name,
         roles: this.state.roles,
@@ -98,7 +97,11 @@ class ProfileEditView extends React.Component {
         throw new Error('There was a problem with network connection. PUT request could not be processed!');
       }
     }.bind(this));
-  };
+  }
+
+  handleRedirect = () => {
+   this.setState({ redirect: true })
+  }
 
   getTags = () => {
     var tags = [];
@@ -120,14 +123,13 @@ class ProfileEditView extends React.Component {
    * Toggles the visiblity of the Snackbar.
    */
   toggleSnackbar = () => {
-    this.setState({
-      snackbarActive: !this.state.snackbarActive
-    })
+    this.setState({ snackbarActive: !this.state.snackbarActive })
   }
 
   render () {
     return (
       <div className="row">
+        { (this.state.redirect) ? <Redirect to="/updatePwd"/> : "" }
         <div className="col-md-2 text-center">
           <Avatar style={{width: '6em', height: '6em', marginBottom: '1em'}} image={this.state.avatarUrl} title={ _t.translate('Your Gravatar') } />
           {this.state.roles.map( (role) => <Chip key={role}> { _t.translate(role) } </Chip> )}
@@ -141,6 +143,7 @@ class ProfileEditView extends React.Component {
           <Input type='text' name='company' label={ _t.translate('Company') } icon='business' disabled value={Util.isEmpty(this.state.company) ? "None" : this.state.company.name} />
           <Input type='hidden' name='roles' label={ _t.translate('Role') } icon='person' disabled value={this.state.roles.toString()} />
           <Input type='text' name='tags' label={ _t.translate('Tags') } icon='flag' hint="Divide tags using ;" value={this.state.tags} onChange={this.handleChange.bind(this, 'tags')} />
+          <Button icon='edit' label={ _t.translate('Change password') } raised primary className='pull-left' onClick={this.handleRedirect}/>
           <Button icon='edit' label={ _t.translate('Save changes') } raised primary className='pull-right' onClick={this.handleSubmit}/>
           <SiteSnackbar active={this.state.snackbarActive} label={this.state.snackbarLabel} toggleHandler={() => this.toggleSnackbar()} />
         </div>
@@ -190,7 +193,7 @@ class CompanyEditView extends React.Component {
 
   handleChange = (name, value) => {
     this.setState({...this.state, [name]: value});
-  };
+  }
 
   handleSubmit = () => {
     fetch('/api/companies/' + this.state.id, {
@@ -223,7 +226,7 @@ class CompanyEditView extends React.Component {
         throw new Error('There was a problem with network connection. PUT request could not be processed!');
       }
     }.bind(this));
-  };
+  }
 
   /**
    * Toggles the visiblity of the Snackbar.

--- a/studenthub-ui/src/views/ResetConfirmation.js
+++ b/studenthub-ui/src/views/ResetConfirmation.js
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import SiteSnackbar from '../components/SiteSnackbar.js';
+
+import _t from '../Translations.js';
+
+class ResetConfirmation extends React.Component {
+  state = {snackbarActive: false, snackbarLabel: ''};
+
+  componentDidMount() {
+    this.handleCheck();
+  }
+
+  handleChange = (name, value) => {
+    this.setState({...this.state, [name]: value});
+  }
+
+  handleCheck = () => {
+    fetch('/api/account/confirmReset?secret=' + this.props.secret +
+      '&id='+this.props.id, {
+      method: 'post'
+    }).then(function(response) {
+      if (response.ok) {
+        this.setState({
+          snackbarLabel: "Your password has been succesfully reset!",
+          snackbarActive: true
+        });
+      } else {
+        this.setState({
+          snackbarLabel: "An error occured! Your request couldn't be processed. It's possible that you have a problem with your internet connection or that the server is not responding.",
+          snackbarActive: true
+        });
+        throw new Error('There was a problem with network connection. POST request could not be processed!');
+      }
+    }.bind(this));
+  }
+
+  handleToggle = () => {
+    this.setState({snackbarActive: !this.state.snackbarActive});
+  }
+
+  render() {
+    return (
+      <div>
+        <SiteSnackbar active={this.state.snackbarActive} label=
+          {this.state.snackbarLabel} toggleHandler={() => this.handleToggle()} />
+      </div>
+    )
+  }
+}
+
+const ResetConfirmationView = ({ match }) => (
+  <div className='text-center col-md-offset-3 col-md-6'>
+    <h1>{ _t.translate('Password reset confirmation') }</h1>
+    <ResetConfirmation id={match.params.id} secret={match.params.secret} />
+  </div>
+);
+
+export default ResetConfirmationView

--- a/studenthub-ui/src/views/ResetConfirmation.js
+++ b/studenthub-ui/src/views/ResetConfirmation.js
@@ -42,8 +42,8 @@ class ResetConfirmation extends React.Component {
   render() {
     return (
       <div>
-        <SiteSnackbar active={this.state.snackbarActive} label=
-          {this.state.snackbarLabel} toggleHandler={() => this.handleToggle()} />
+        <SiteSnackbar active={this.state.snackbarActive} label={this.state.snackbarLabel}
+          toggleHandler={() => this.handleToggle()} />
       </div>
     )
   }

--- a/studenthub-ui/src/views/UpdatePassword.js
+++ b/studenthub-ui/src/views/UpdatePassword.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Redirect } from 'react-router';
+import Input from 'react-toolbox/lib/input/Input.js';
+import Button from 'react-toolbox/lib/button/Button.js';
+
+import SiteSnackbar from '../components/SiteSnackbar.js';
+
+import Auth from '../Auth.js';
+import _t from '../Translations.js';
+
+class UpdatePasswordView extends React.Component {
+  state = { oldPwd: '', newPwd: '', snackbarActive: false, snackbarLabel: '', redirect: false };
+
+  handleChange = (name, value) => {
+    this.setState({...this.state, [name]: value});
+  };
+
+  handleSubmit = () => {
+    fetch('/api/users/' + Auth.getUserInfo().sub + '/password', {
+      method: 'put',
+      credentials: 'same-origin',
+      headers: { "Content-Type" : "application/json" },
+      body: JSON.stringify({
+        newPwd: this.state.newPwd,
+        oldPwd: this.state.oldPwd
+      })
+    }).then(function(response) {
+        if(response.ok) {
+          this.setState({
+            snackbarLabel: "Your password has been succesfully changed!",
+            snackbarActive: true
+          });
+          setTimeout(function(){
+            this.setState({ redirect: true });
+          }.bind(this), 2000);
+      }
+      else if (response.status === 404) {
+        this.setState({
+          snackbarLabel: "You have written your old password incorrectly!",
+          snackbarActive: true
+        });
+      }
+      else {
+        this.setState({
+          snackbarLabel: "An error occured! Your request couldn't be processed. It's possible that you have a problem with your internet connection or that the server is not responding.",
+          snackbarActive: true
+        });
+        throw new Error('There was a problem with network connection. PUT request could not be processed!');
+      }
+    }.bind(this));
+  }
+
+  handleToggle = () => {
+    this.setState({ snackbarActive: false });
+  }
+
+  generateRedirect = () => {
+    if(this.state.redirect === false) return;
+    else return (<Redirect to="/profile" />);
+  }
+
+  render () {
+    return (
+      <section className='text-center col-md-offset-3 col-md-6'>
+        <h1>{ _t.translate('Password update') }</h1>
+        <Input type='password' label={ _t.translate('Old password') } hint='Your current password' icon='lock' required
+          value={this.state.oldPwd} onChange={this.handleChange.bind(this, 'oldPwd')} />
+        <Input type='password' label={ _t.translate('New password') } hint='Your desired new password' icon='lock' required
+          value={this.state.newPwd} onChange={this.handleChange.bind(this, 'newPwd')} />
+        <br />
+        <Button icon='send' label={ _t.translate('Change') } raised primary onClick={this.handleSubmit}/>
+        {this.generateRedirect()}
+        <SiteSnackbar active={this.state.snackbarActive} toggleHandler={() => this.handleToggle()} label={this.state.snackbarLabel} />
+      </section>
+    );
+  }
+}
+
+export default UpdatePasswordView;


### PR DESCRIPTION
* `[POST] account/resetPassword` now sends mail which needs to be confirmed in order to actually reset the password.
  * Added endpoint `[POST] account/confirmReset`, which acts as resetPassword before.
* `Activation` now has additional field called `type`, which specifies type of `Activation`.
* Added template for resetPassword email.