### PR TITLE
#169 - Add @Url validator to all url fields

### DIFF
--- a/studenthub-portal/initial-data.xml
+++ b/studenthub-portal/initial-data.xml
@@ -16,7 +16,7 @@
             <column name="name" value="Company One"/>
             <column name="plan_name" value="TIER_1"/>
             <column name="size" value="CORPORATE"/>
-            <column name="url" value="www.c1.com"/>
+            <column name="url" value="http://www.c1.com"/>
         </insert>
         <sql>SELECT setval('companies_id_seq', 1)</sql>
     </changeSet>
@@ -27,7 +27,7 @@
             <column name="country" value="CZ"/>
             <column name="logourl" value="www.muni.cz/img.png"/>
             <column name="name" value="Masaryk University"/>
-            <column name="url" value="www.muni.cz"/>
+            <column name="url" value="http://www.muni.cz"/>
         </insert>
         <sql>SELECT setval('universities_id_seq', 1)</sql>
     </changeSet>

--- a/studenthub-portal/src/main/java/cz/studenthub/core/Company.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/Company.java
@@ -31,6 +31,7 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.constraints.URL;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
@@ -47,11 +48,14 @@ public class Company {
   @NotEmpty
   private String name;
 
+  @URL
   private String url;
   private String city;
 
   @Enumerated(EnumType.STRING)
   private Country country;
+
+  @URL
   private String logoUrl;
 
   @Enumerated(EnumType.STRING)

--- a/studenthub-portal/src/main/java/cz/studenthub/core/University.java
+++ b/studenthub-portal/src/main/java/cz/studenthub/core/University.java
@@ -29,6 +29,7 @@ import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
 import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.constraints.URL;
 
 @Entity
 @Table(name = "Universities")
@@ -42,11 +43,14 @@ public class University {
   @NotEmpty
   private String name;
 
+  @URL
   private String url;
   private String city;
 
   @Enumerated(EnumType.STRING)
   private Country country;
+
+  @URL
   private String logoUrl;
 
   public University() {

--- a/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.1.xml
+++ b/studenthub-portal/src/main/resources/db/changelog/db.changelog-1.1.xml
@@ -83,4 +83,10 @@
         <dropForeignKeyConstraint baseTableName="activations" constraintName="fko7msy6sghrksg7w9up2m9pl0n"/>
         <addForeignKeyConstraint baseColumnNames="user_id" baseTableCatalogName="studenthub" baseTableName="activations" baseTableSchemaName="public" constraintName="fko7msy6sghrksg7w9up2m9pl0n" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableCatalogName="studenthub" referencedTableName="users" referencedTableSchemaName="public"/>
     </changeSet>
+    <changeSet author="phala" id="url">
+        <modifyDataType catalogName="studenthub" columnName="url" newDataType="VARCHAR(2047)" schemaName="public" tableName="companies"/>
+        <modifyDataType catalogName="studenthub" columnName="logourl" newDataType="VARCHAR(2047)" schemaName="public" tableName="companies"/>
+        <modifyDataType catalogName="studenthub" columnName="url" newDataType="VARCHAR(2047)" schemaName="public" tableName="universities"/>
+        <modifyDataType catalogName="studenthub" columnName="logourl" newDataType="VARCHAR(2047)" schemaName="public" tableName="universities"/>
+    </changeSet>
 </databaseChangeLog>

--- a/studenthub-portal/src/test/java/cz/studenthub/db/CompanyDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/CompanyDAOTest.java
@@ -30,7 +30,7 @@ public class CompanyDAOTest {
   public void createCompany() {
     DAOTestSuite.inRollbackTransaction(() -> {
       CompanyPlan cPlan = cpDAO.findByName("TIER_2");
-      Company company = new Company("New", "www.nothing.eu", "Liberec", Country.CZ, "www.nothing.eu/logo.png",
+      Company company = new Company("New", "http://www.nothing.eu", "Liberec", Country.CZ, "http://www.nothing.eu/logo.png",
           CompanySize.SMALL, cPlan);
       Company created = companyDAO.create(company);
       List<Company> companies = companyDAO.findAll();

--- a/studenthub-portal/src/test/java/cz/studenthub/db/UniversityDAOTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/db/UniversityDAOTest.java
@@ -24,7 +24,7 @@ public class UniversityDAOTest {
 
   @Test
   public void createUniversity() {
-    University uni = new University("BUT", "www.nothing.com", "Brno", Country.CZ, "/img.jpg");
+    University uni = new University("BUT", "http://www.nothing.com", "Brno", Country.CZ, "http://nothing.com/img.jpg");
     DAOTestSuite.inRollbackTransaction(() -> {
       University created = uniDAO.create(uni);
       List<University> universities = uniDAO.findAll();

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/CompanyResourceTest.java
@@ -81,7 +81,7 @@ public class CompanyResourceTest {
     plan.put("name", "TIER_1");
 
     JSONObject company = new JSONObject();
-    company.put("url", "past.me");
+    company.put("url", "http://www.past.me");
     company.put("name", "New Company");
     company.put("plan", plan);
 
@@ -90,7 +90,7 @@ public class CompanyResourceTest {
 
     assertNotNull(response);
     assertEquals(response.getStatus(), 200);
-    assertEquals(response.readEntity(Company.class).getUrl(), "past.me");
+    assertEquals(response.readEntity(Company.class).getUrl(), "http://www.past.me");
   }
 
   @Test(dependsOnMethods = "updateCompany")

--- a/studenthub-portal/src/test/java/cz/studenthub/integration/UniversityResourceTest.java
+++ b/studenthub-portal/src/test/java/cz/studenthub/integration/UniversityResourceTest.java
@@ -57,7 +57,7 @@ public class UniversityResourceTest {
   public void createUniversity() {
     JSONObject university = new JSONObject();
     university.put("name", "Unknown");
-    university.put("url", "past.me");
+    university.put("url", "http://www.past.me");
     university.put("city", "Brno");
 
     Response response = IntegrationTestSuite.authorizedRequest(client.target(String.format("http://localhost:%d/api/universities", dropwizard.getLocalPort()))

--- a/studenthub-portal/src/test/resources/db/test-data.xml
+++ b/studenthub-portal/src/test/resources/db/test-data.xml
@@ -31,7 +31,7 @@
             <column name="NAME" value="Company Two"/>
             <column name="PLAN_NAME" value="TIER_2"/>
             <column name="SIZE" value="MEDIUM"/>
-            <column name="URL" value="www.c2.com"/>
+            <column name="URL" value="http://www.c2.com"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="1"/>
@@ -41,7 +41,7 @@
             <column name="NAME" value="Company One"/>
             <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="CORPORATE"/>
-            <column name="URL" value="www.c1.com"/>
+            <column name="URL" value="http://www.c1.com"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="3"/>
@@ -51,7 +51,7 @@
             <column name="NAME" value="Company Three"/>
             <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="SMALL"/>
-            <column name="URL" value="www.c3.com"/>
+            <column name="URL" value="http://www.c3.com"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="4"/>
@@ -61,7 +61,7 @@
             <column name="NAME" value="Company Four"/>
             <column name="PLAN_NAME" value="TIER_1"/>
             <column name="SIZE" value="STARTUP"/>
-            <column name="URL" value="www.c4.com"/>
+            <column name="URL" value="http://www.c4.com"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="5"/>
@@ -71,7 +71,7 @@
             <column name="NAME" value="Company Five"/>
             <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="MEDIUM"/>
-            <column name="URL" value="www.c5.com"/>
+            <column name="URL" value="http://www.c5.com"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="6"/>
@@ -81,7 +81,7 @@
             <column name="NAME" value="Company Six"/>
             <column name="PLAN_NAME" value="TIER_2"/>
             <column name="SIZE" value="CORPORATE"/>
-            <column name="URL" value="www.c6.com"/>
+            <column name="URL" value="http://www.c6.com"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="7"/>
@@ -91,7 +91,7 @@
             <column name="NAME" value="Company Seven"/>
             <column name="PLAN_NAME" value="TIER_3"/>
             <column name="SIZE" value="MEDIUM"/>
-            <column name="URL" value="www.c7.com"/>
+            <column name="URL" value="http://www.c7.com"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="COMPANIES">
             <column name="ID" valueNumeric="8"/>
@@ -101,7 +101,7 @@
             <column name="NAME" value="Company Eight"/>
             <column name="PLAN_NAME" value="TIER_1"/>
             <column name="SIZE" value="STARTUP"/>
-            <column name="URL" value="www.c8.com"/>
+            <column name="URL" value="http://www.c8.com"/>
         </insert>
     </changeSet>
     
@@ -112,7 +112,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="www.muni.cz/img.png"/>
             <column name="NAME" value="Masaryk University"/>
-            <column name="URL" value="www.muni.cz"/>
+            <column name="URL" value="http://www.muni.cz"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="UNIVERSITIES">
             <column name="ID" valueNumeric="3"/>
@@ -120,7 +120,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="www.cvut.cz/image.jpg"/>
             <column name="NAME" value="Czech Technical University"/>
-            <column name="URL" value="www.cvut.cz"/>
+            <column name="URL" value="http://www.cvut.cz"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="UNIVERSITIES">
             <column name="ID" valueNumeric="4"/>
@@ -128,7 +128,7 @@
             <column name="COUNTRY" value="SK"/>
             <column name="LOGOURL" value="www.stuba.sk/logo.jpg"/>
             <column name="NAME" value="Slovak Technical University"/>
-            <column name="URL" value="www.stuba.sk"/>
+            <column name="URL" value="http://www.stuba.sk"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="UNIVERSITIES">
             <column name="ID" valueNumeric="5"/>
@@ -136,7 +136,7 @@
             <column name="COUNTRY" value="SK"/>
             <column name="LOGOURL" value="www.uniba.sk/logo.gif"/>
             <column name="NAME" value="Comenius University in Bratislava"/>
-            <column name="URL" value="uniba.sk"/>
+            <column name="URL" value="http://uniba.sk"/>
         </insert>
         <insert catalogName="STUDENTHUB" schemaName="PUBLIC" tableName="UNIVERSITIES">
             <column name="ID" valueNumeric="2"/>
@@ -144,7 +144,7 @@
             <column name="COUNTRY" value="CZ"/>
             <column name="LOGOURL" value="www.vut.cz/logo.png"/>
             <column name="NAME" value="Brno University of Technology"/>
-            <column name="URL" value="www.vut.cz"/>
+            <column name="URL" value="http://www.vut.cz"/>
         </insert>
     </changeSet>
     <changeSet author="phala (generated)" id="1489653927422-19" objectQuotingStrategy="QUOTE_ALL_OBJECTS">


### PR DESCRIPTION
* All url fields now have to be proper URL.
   * This means protocol, like `http` or `https`, **has** to be specified.
   * Extended maximum URL length to be 2047 characters because that is around the limit that IE has and frankly I don't think anyone will have longer URL than this.
* Updated testing configurations to reflect this change.